### PR TITLE
docs: README 列出 issue-driven-dev 仰賴的外部 plugin / MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ claude plugin marketplace add PsychQuant/issue-driven-development
 claude plugin install issue-driven-dev@issue-driven-development
 ```
 
+## Requirements
+
+IDD core 是零依賴的 — 純文字 issue / `/idd-issue` 直接貼描述、`/idd-diagnose` / `/idd-implement` / `/idd-close` 都不需要任何外部 plugin。
+
+某些情境需要額外裝 plugin:
+
+- **`.docx` / Telegram / Apple Mail / Apple Notes 來源** — `/idd-issue` 從這些來源讀文字 + 抽附件需對應 MCP plugin
+- **`idd-verify --loop` / `idd-all` (PR, unattended) mode** — 需要 [`ralph-loop`](https://github.com/anthropics/claude-plugins-official) 作為 outer driver(#28 預計補完整文件)
+- **`idd-verify` 6-AI ensemble** — 需要 [OpenAI Codex CLI](https://github.com/openai/codex) + ChatGPT Pro
+
+完整 matrix 與 install 指令見 [`plugins/issue-driven-dev/README.md#requirements`](./plugins/issue-driven-dev/README.md#requirements)。
+
 ## Why a separate marketplace?
 
 IDD is a methodology unto itself with its own [MANIFESTO](./plugins/issue-driven-dev/MANIFESTO.md) and steady release cadence (38+ versions). Pulling it out of `psychquant-claude-plugins` (which has ~36 unrelated plugins) gives:

--- a/plugins/issue-driven-dev/README.md
+++ b/plugins/issue-driven-dev/README.md
@@ -179,6 +179,27 @@ attachments_release: "attachments"
 
 ## Requirements
 
+### Required (always)
+
 - `gh` CLI authenticated with GitHub
 - [OpenAI Codex CLI](https://github.com/openai/codex) installed (for `idd-verify`)
 - ChatGPT Pro account (for Codex gpt-5.5)
+
+### Optional (per source type)
+
+`/idd-issue` 支援多種來源類型。文字直接貼進 prompt 不需要任何 plugin;若要從以下來源讀取,需另裝對應 MCP plugin:
+
+| Source type | MCP plugin | Why | Install |
+|-------------|------------|-----|---------|
+| `.docx` / `.doc` | `che-word-mcp` | `idd-issue` Step 1 用 `mcp__che-word-mcp__get_document_text` / `list_images` / `export_image` 讀文字 + 抽圖 | `claude plugin install che-word-mcp@<your-marketplace>` |
+| Telegram chat range | `che-telegram-mcp` (telegram-all server) | 讀 chat history (`get_chat_history`) | `claude plugin install che-telegram-mcp@<your-marketplace>` |
+| Apple Mail message | `che-apple-mail-mcp` | `get_email` + `list_attachments` + `save_attachment` | `claude plugin install che-apple-mail-mcp@<your-marketplace>` |
+| Apple Notes | `che-apple-notes-mcp` | `get_note` + 抽 inline 圖 | `claude plugin install che-apple-notes-mcp@<your-marketplace>` |
+
+替換 `<your-marketplace>` 為實際的 marketplace 名稱(例如 `che-claude-plugins`)。沒裝對應 plugin 不會壞 IDD 核心流程,但該 source type 會被迫 fallback 到「使用者手動處理」模式 (#27 追蹤改為明確 fail-fast 報錯)。
+
+### Sister plugins
+
+- [`idd-route`](../idd-route) — Data-driven agent routing (Codex / Claude Opus / Sonnet / Haiku) per IDD issue。`idd-diagnose` Step 3.7 偵測到 `idd-route` 已裝就會自動呼叫做 enrichment;沒裝則 silently skip。**非必要**,純粹增強 routing 建議品質。Install: `claude plugin install idd-route@issue-driven-development`
+
+> **Note**:`idd-verify --loop` 與 `idd-all` (PR, unattended) mode 另外仰賴 `ralph-loop` plugin 作為 outer driver — 詳見 #28(預計在 follow-up release 補上完整文件 + skill auto-detect)。

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -262,6 +262,8 @@ UPSTREAM=$(echo "$REPO_JSON" | jq -r '.parent.nameWithOwner // empty')
 
 #### Source Type Adapter
 
+<!-- KEEP IN SYNC: plugins/issue-driven-dev/README.md#optional-per-source-type — 加新 source type 必須同步更新 README matrix -->
+
 依來源類型挑對應的讀取 + 抽附件 tool；**Step 4 上傳時不分類型，一視同仁全部 push 到 release**。
 
 | Source type | 讀文字 | 抽附件 |


### PR DESCRIPTION
Refs #26

## Summary

擴充兩份 README 的 `## Requirements` section,清楚說明 IDD 對外部 plugin 的依賴(依 source type / mode 分層)。

- **plugin README** — 重組 `## Requirements` 為 Required (always) / Optional (per source type) / Sister plugins 三節,加 4-row MCP plugin matrix
- **頂層 README** — 新增 `## Requirements` summary + link to plugin README anchor (avoid duplicate matrix)
- **idd-issue SKILL.md** — 加 `<!-- KEEP IN SYNC -->` HTML comment 防 source type adapter table ↔ README matrix drift

頁面結構為 #28 (ralph-loop dependency) future Layer 1 預留 `### Required for specific modes` 插入空間,避免 #28 還要重組同一個 section。

## Checklist

- [x] Diagnose (https://github.com/PsychQuant/issue-driven-development/issues/26#issuecomment-4393045256)
- [x] Implement (3 commits)
- [ ] Verify (run /idd-verify --pr <this PR>)
- [ ] **Pending: human review of this PR + /idd-close after merge**

---

Generated by /idd-implement on PR path. **Do NOT add 'Closes #26'** — IDD discipline requires manual /idd-close after merge to enforce checklist gate + closing summary.