### PR TITLE
docs: marketplace lookup hint + 對照表 — fix #26 placeholder UX gap

### DIFF
--- a/plugins/issue-driven-dev/README.md
+++ b/plugins/issue-driven-dev/README.md
@@ -206,7 +206,7 @@ attachments_release: "attachments"
 >
 >    | Plugin pattern | Marketplace | Add command |
 >    |----------------|-------------|-------------|
->    | `che-*` (incl. `che-word-mcp` / `che-telegram-mcp` / `che-apple-mail-mcp` / `che-apple-notes-mcp`) | `che-claude-plugins` | `claude plugin marketplace add PsychQuant/che-claude-plugins` |
+>    | `che-*` (incl. `che-word-mcp` / `che-telegram-mcp` / `che-apple-mail-mcp` / `che-apple-notes-mcp`) | `psychquant-claude-plugins` | `claude plugin marketplace add PsychQuant/psychquant-claude-plugins` |
 >    | `idd-*` (本 plugin / `idd-route`) | `issue-driven-development` | `claude plugin marketplace add PsychQuant/issue-driven-development` |
 >    | `ralph-loop` (Anthropic 官方) | `claude-plugins-official` | `claude plugin marketplace add anthropics/claude-plugins-official` |
 

--- a/plugins/issue-driven-dev/README.md
+++ b/plugins/issue-driven-dev/README.md
@@ -196,7 +196,19 @@ attachments_release: "attachments"
 | Apple Mail message | `che-apple-mail-mcp` | `get_email` + `list_attachments` + `save_attachment` | `claude plugin install che-apple-mail-mcp@<your-marketplace>` |
 | Apple Notes | `che-apple-notes-mcp` | `get_note` + 抽 inline 圖 | `claude plugin install che-apple-notes-mcp@<your-marketplace>` |
 
-替換 `<your-marketplace>` 為實際的 marketplace 名稱(例如 `che-claude-plugins`)。沒裝對應 plugin 不會壞 IDD 核心流程,但該 source type 會被迫 fallback 到「使用者手動處理」模式 (#27 追蹤改為明確 fail-fast 報錯)。
+替換 `<your-marketplace>` 為實際的 marketplace 名稱。沒裝對應 plugin 不會壞 IDD 核心流程,但該 source type 會被迫 fallback 到「使用者手動處理」模式 (#27 追蹤改為明確 fail-fast 報錯)。
+
+> **不知道 `<your-marketplace>` 該填什麼?**
+>
+> 1. 查已加的 marketplaces:`claude plugin marketplace list`
+> 2. 加新 marketplace:`claude plugin marketplace add <owner>/<repo>`
+> 3. 常見對照(以 PsychQuant 維護的 plugins 為例,如有變動以 `claude plugin marketplace list` 為準):
+>
+>    | Plugin pattern | Marketplace | Add command |
+>    |----------------|-------------|-------------|
+>    | `che-*` (incl. `che-word-mcp` / `che-telegram-mcp` / `che-apple-mail-mcp` / `che-apple-notes-mcp`) | `che-claude-plugins` | `claude plugin marketplace add PsychQuant/che-claude-plugins` |
+>    | `idd-*` (本 plugin / `idd-route`) | `issue-driven-development` | `claude plugin marketplace add PsychQuant/issue-driven-development` |
+>    | `ralph-loop` (Anthropic 官方) | `claude-plugins-official` | `claude plugin marketplace add anthropics/claude-plugins-official` |
 
 ### Sister plugins
 


### PR DESCRIPTION
Refs #31

## Summary
在 `## Requirements > ### Optional (per source type)` matrix 下方加 lookup hint blockquote — 含 `claude plugin marketplace list` / `add` 命令 + 3-row 常見對照表 (`che-*` / `idd-*` / `ralph-loop`),解決 #26 placeholder UX gap。

## Verification
Lightweight self-verify PASS (純 docs 1-block insertion)。Verify caught 1 blocking finding (`che-*` marketplace name 誤寫,被 GitHub redirect 騙到) → auto-fixed in commit `7d3f6b6` round 1。詳見 issue #31 Verify comment。

## Checklist
- [x] Diagnose ✓ (Simple complexity, V1=1 V4=2)
- [x] Implement (1 commit + 1 verify-fix commit)
- [x] Verify ✓ (lightweight self-verify, 1 finding auto-fixed)
- [ ] **Pending: human review of this PR + /idd-close after merge**

## Related
- #26 (parent — placeholder design choice)
- #28 (頂層 README mode-required dependency 留給 #28 Layer 1 處理)

---
🤖 Generated by /idd-all. **Do NOT add 'Closes #31'** — IDD discipline requires manual /idd-close after merge.