### PR TITLE
feat(check-diagnosis-readiness): extract Step 0.4 helper script (#51)

### DIFF
--- a/plugins/issue-driven-dev/references/chain-flow.md
+++ b/plugins/issue-driven-dev/references/chain-flow.md
@@ -32,7 +32,7 @@ When detection finds no diagnosis comment, the chain shell fires `AskUserQuestio
 
 **Why placement before branch/manifest creation matters**: cancel-path side-effect minimization. If user picks `cancel`, no work is undone — there is no work yet. Diagnosis-readiness gate placed AFTER branch creation would leave dangling cluster branches user must manually delete, breaking IDD's halt+preserve discipline (preserve assumes there's something worth preserving).
 
-**Future #46 multi-root extension**: helper function design preserves N-arg shape (`check_diagnosis_readiness(issue_numbers...) → [ready_list, not_ready_list]`) so #46 can reuse for per-root readiness aggregation. v1 ships single-root only.
+**Implementation** (v2.57.0+, #51): extracted from inline bash to standalone helper at `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh`. Variadic positional signature: `check-diagnosis-readiness.sh <github-repo> <issue-number> [<issue-number>...]` emits `{"ready":[N,...],"not_ready":[N,...]}` JSON to stdout. Exit codes 0 (success) / 1 (gh-jq failure) / 2 (usage error) per `manifest-append.sh` precedent. v1 single-root invocation;ready for #46 multi-root chain to call with multiple issue numbers without API change.
 
 ## Cluster branch naming
 

--- a/plugins/issue-driven-dev/references/chain-flow.md
+++ b/plugins/issue-driven-dev/references/chain-flow.md
@@ -32,7 +32,7 @@ When detection finds no diagnosis comment, the chain shell fires `AskUserQuestio
 
 **Why placement before branch/manifest creation matters**: cancel-path side-effect minimization. If user picks `cancel`, no work is undone — there is no work yet. Diagnosis-readiness gate placed AFTER branch creation would leave dangling cluster branches user must manually delete, breaking IDD's halt+preserve discipline (preserve assumes there's something worth preserving).
 
-**Implementation** (v2.57.0+, #51): extracted from inline bash to standalone helper at `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh`. Variadic positional signature: `check-diagnosis-readiness.sh <github-repo> <issue-number> [<issue-number>...]` emits `{"ready":[N,...],"not_ready":[N,...]}` JSON to stdout. Exit codes 0 (success) / 1 (gh-jq failure) / 2 (usage error) per `manifest-append.sh` precedent. v1 single-root invocation;ready for #46 multi-root chain to call with multiple issue numbers without API change.
+**Implementation** (v2.57.0+, #51): extracted from inline bash to standalone helper at `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh`. Variadic positional signature: `check-diagnosis-readiness.sh <github-repo> <issue-number> [<issue-number>...]` emits `{"ready":[N,...],"not_ready":[N,...]}` JSON to stdout. Exit codes 0 (success) / 1 (gh-jq failure) / 2 (usage error) per `manifest-append.sh` precedent. v1 single-root invocation; ready for #46 multi-root chain to call with multiple issue numbers without API change.
 
 ## Cluster branch naming
 

--- a/plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh
+++ b/plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh
@@ -55,7 +55,8 @@ READY=()
 NOT_READY=()
 
 for n in "$@"; do
-  if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+  # Strict positive-integer check: GitHub has no issue #0, so reject "0" too.
+  if ! [[ "$n" =~ ^[1-9][0-9]*$ ]]; then
     echo "ERROR: '$n' is not a positive integer issue number" >&2
     usage
   fi

--- a/plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh
+++ b/plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# check-diagnosis-readiness.sh — classify N issues into ready/not_ready by ## Diagnosis presence
+#
+# Used by /idd-all-chain Step 0.4 (single-root in v1) and reserved for #46 multi-root chain.
+#
+# Usage:
+#   check-diagnosis-readiness.sh <github-repo> <issue-number> [<issue-number>...]
+#
+# Stdout (success): JSON {"ready":[N,...],"not_ready":[N,...]}
+# Exit:
+#   0 — success
+#   1 — gh / jq failure (auth, network, non-existent issue)
+#   2 — usage error
+#
+# Detection regex (per PsychQuant/issue-driven-development#53):
+#   `test("(?m)^## Diagnosis")` — line-anchored, avoids quoted-history false-positives.
+#
+# See: plugins/issue-driven-dev/references/chain-flow.md for chain-shell context
+
+set -u
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <github-repo> <issue-number> [<issue-number>...]
+
+Arguments:
+  github-repo    GitHub repo in owner/repo form (e.g. PsychQuant/issue-driven-development)
+  issue-number   one or more positive integer issue numbers
+
+Stdout (success):
+  JSON {"ready":[N,...],"not_ready":[N,...]}
+
+Exit:
+  0 — success
+  1 — gh / jq failure
+  2 — usage error
+EOF
+  exit 2
+}
+
+if [ $# -lt 2 ]; then
+  usage
+fi
+
+GITHUB_REPO="$1"
+shift
+
+# Validate GITHUB_REPO shape
+if ! [[ "$GITHUB_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "ERROR: '$GITHUB_REPO' is not in owner/repo form" >&2
+  usage
+fi
+
+READY=()
+NOT_READY=()
+
+for n in "$@"; do
+  if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: '$n' is not a positive integer issue number" >&2
+    usage
+  fi
+
+  count=$(gh issue view "$n" -R "$GITHUB_REPO" --json comments 2>/dev/null \
+    | jq -r '[.comments[] | select(.body | test("(?m)^## Diagnosis"))] | length' \
+    2>/dev/null)
+
+  if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: gh/jq failed for issue #$n in $GITHUB_REPO (auth, network, or issue not found)" >&2
+    exit 1
+  fi
+
+  if [ "$count" = "0" ]; then
+    NOT_READY+=("$n")
+  else
+    READY+=("$n")
+  fi
+done
+
+# Emit JSON. Use jq -n with empty arrays as sentinels so unset variables don't
+# trip set -u when an array has 0 elements.
+ready_json=$(printf '%s\n' "${READY[@]+"${READY[@]}"}" | grep -v '^$' | jq -R 'tonumber' | jq -s . 2>/dev/null)
+not_ready_json=$(printf '%s\n' "${NOT_READY[@]+"${NOT_READY[@]}"}" | grep -v '^$' | jq -R 'tonumber' | jq -s . 2>/dev/null)
+ready_json=${ready_json:-[]}
+not_ready_json=${not_ready_json:-[]}
+
+jq -nc \
+  --argjson r "$ready_json" \
+  --argjson nr "$not_ready_json" \
+  '{ready: $r, not_ready: $nr}'

--- a/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
@@ -62,7 +62,7 @@ Inherits `/idd-all` config protocol (walked-up `.claude/issue-driven-dev.local.j
 
 ```
 TaskCreate(name="preflight", description="Phase 0: 解析 args、gh auth、確認 root issue OPEN")
-TaskCreate(name="check_diagnosis_readiness", description="Phase 0.4 (NEW, v2.55+ #47): gh issue view --json comments + jq filter '## Diagnosis'; found → silent pass; not found → AskUserQuestion 3-option (run /idd-diagnose first / proceed anyway / cancel). Placed before cluster branch / manifest creation so cancel has zero side effect.")
+TaskCreate(name="check_diagnosis_readiness", description="Phase 0.4 (v2.55+ #47, helper extracted v2.57+ #51): invoke scripts/check-diagnosis-readiness.sh <github-repo> <root-issue> → JSON {ready/not_ready}; not_ready=0 → silent pass; not_ready>0 → AskUserQuestion 3-option (run /idd-diagnose first / proceed anyway / cancel). Placed before cluster branch / manifest creation so cancel has zero side effect.")
 TaskCreate(name="setup_cluster_branch", description="Phase 0: 建 cluster branch idd/chain-N-<slug> from default branch + 初始化 spawn manifest")
 TaskCreate(name="init_queue", description="Phase 1: queue = [root], depth_map = {root: 0}, closed_set = {}")
 TaskCreate(name="chain_loop", description="Phase 2: 主 loop — pop queue, invoke /idd-all #current --in-chain, read manifest, enqueue eligible spawns until queue empty / depth limit / max-issues cap reached / verify FAIL halt")
@@ -209,7 +209,7 @@ fi
 gh issue edit "$ROOT_ISSUE" -R "$GITHUB_REPO" --body "$NEW_BODY"
 ```
 
-> **Future #46 multi-root extension hook**:#46 multi-root chain 落地時,本 step 的 detection logic 應 refactor 成 named helper function `check_diagnosis_readiness(issue_numbers...)` return `[ready_list, not_ready_list]` struct,讓 multi-root 可批次 check + 聚合 AskUserQuestion。**Currently inline only**(待 #46 + #51 follow-up issue 處理)— 本 step v1 single-root sufficient。
+> **#46 multi-root extension hook** (v2.57.0+, #51 shipped): detection logic is now extracted to `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh` with variadic positional signature `<github-repo> <issue-number> [<issue-number>...]` returning `{"ready":[N,...],"not_ready":[N,...]}` JSON. v1 single-root invocation;ready for #46 multi-root chain to call with multiple issue numbers + aggregate AskUserQuestion across roots without API change. See `references/chain-flow.md` for canonical signature.
 
 > **Removed pseudo-fallback for unattended caller**: 早期 design 含 `IN_CHAIN_CONTEXT` env var 偵測作 unattended fallback,但實際 repo 中**無任何 producer** sets this var(/idd-verify #47 P1 finding 1)。`/idd-all-chain` 是 user-invoked deliberation moment,沒 unattended caller path,該 env detection 是 dead code,移除。若未來真有 unattended caller,需明確設計 producer + 文件化 detection convention。
 

--- a/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
@@ -209,7 +209,7 @@ fi
 gh issue edit "$ROOT_ISSUE" -R "$GITHUB_REPO" --body "$NEW_BODY"
 ```
 
-> **#46 multi-root extension hook** (v2.57.0+, #51 shipped): detection logic is now extracted to `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh` with variadic positional signature `<github-repo> <issue-number> [<issue-number>...]` returning `{"ready":[N,...],"not_ready":[N,...]}` JSON. v1 single-root invocation;ready for #46 multi-root chain to call with multiple issue numbers + aggregate AskUserQuestion across roots without API change. See `references/chain-flow.md` for canonical signature.
+> **#46 multi-root extension hook** (v2.57.0+, #51 shipped): detection logic is now extracted to `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh` with variadic positional signature `<github-repo> <issue-number> [<issue-number>...]` returning `{"ready":[N,...],"not_ready":[N,...]}` JSON. v1 single-root invocation; ready for #46 multi-root chain to call with multiple issue numbers + aggregate AskUserQuestion across roots without API change. See `references/chain-flow.md` for canonical signature.
 
 > **Removed pseudo-fallback for unattended caller**: 早期 design 含 `IN_CHAIN_CONTEXT` env var 偵測作 unattended fallback,但實際 repo 中**無任何 producer** sets this var(/idd-verify #47 P1 finding 1)。`/idd-all-chain` 是 user-invoked deliberation moment,沒 unattended caller path,該 env detection 是 dead code,移除。若未來真有 unattended caller,需明確設計 producer + 文件化 detection convention。
 

--- a/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
@@ -124,31 +124,36 @@ Chain 預期 root issue 已 spec 收斂(有 `## Diagnosis` comment)。沒收斂�
 
 ##### Detection (bash)
 
+Delegated to `scripts/check-diagnosis-readiness.sh` (v2.57.0+, #51) — variadic helper following `manifest-append.sh` precedent. v1 single-root invocation;ready for #46 multi-root extension to call with multiple issue numbers without API change.
+
 ```bash
-# Detect via comments[*].body — NOT issue body
-# (precise — avoids false-positive on issue body discussing "diagnosis" concept)
-# Enable strict mode: gh / jq failure should NOT silently set HAS_DIAGNOSIS=""
-# (which would then equal "0" in `=` test below and silently skip the gate).
+# Helper script does the per-issue gh+jq detection (regex test("(?m)^## Diagnosis") per #53).
+# Returns: {"ready":[N,...],"not_ready":[N,...]} JSON to stdout.
+# Exit: 0 success / 1 gh-jq failure / 2 usage error.
 set -e
 
-HAS_DIAGNOSIS=$(gh issue view "$ROOT_ISSUE" -R "$GITHUB_REPO" --json comments \
-    | jq -r '[.comments[] | select(.body | test("(?m)^## Diagnosis"))] | length')
+READINESS_JSON=$(bash "$CLAUDE_PLUGIN_ROOT/scripts/check-diagnosis-readiness.sh" \
+                  "$GITHUB_REPO" "$ROOT_ISSUE")
 
-# Defensive: if upstream returned empty/non-numeric, treat as infrastructure failure not silent pass
-if ! [[ "$HAS_DIAGNOSIS" =~ ^[0-9]+$ ]]; then
-  abort "Diagnosis-readiness check failed: gh/jq returned non-numeric output ('$HAS_DIAGNOSIS'). Investigate gh auth / network and retry."
+# Parse: count not_ready entries. Single-root v1 → ready=[N] OR not_ready=[N].
+NOT_READY_COUNT=$(echo "$READINESS_JSON" | jq -r '.not_ready | length')
+
+# Defensive: jq failure → abort (helper script already failed-fast via exit 1 to stderr,
+# but if jq parse here also fails the abort still fires).
+if ! [[ "$NOT_READY_COUNT" =~ ^[0-9]+$ ]]; then
+  abort "Diagnosis-readiness parse failed: helper output not parsable JSON. Investigate scripts/check-diagnosis-readiness.sh output."
 fi
 ```
 
-If `HAS_DIAGNOSIS != 0` → diagnosis comment exists → silent pass, fall through to Step 0.5。
+If `NOT_READY_COUNT == 0` → diagnosis comment exists → silent pass, fall through to Step 0.5。
 
-If `HAS_DIAGNOSIS == 0` → no diagnosis comment → enter the AskUserQuestion deliberation moment described below。
+If `NOT_READY_COUNT > 0` → no diagnosis comment → enter the AskUserQuestion deliberation moment described below。
 
 ##### AskUserQuestion deliberation (prose — NOT a bash function call)
 
-> **Why prose instead of bash**: `AskUserQuestion` is a Claude Code tool invoked at the agent level, **not** a binary on `$PATH` or a shell function. Embedding `AskUserQuestion(...)` inside a fenced bash block was a category error caught in /idd-verify #47 (P1 finding 2). The agent reads the bash detection logic, branches at the agent level on `HAS_DIAGNOSIS == 0`, then handles the deliberation as described in prose here. Same pattern as `idd-all/SKILL.md` Phase 0.5 ask-policy interaction.
+> **Why prose instead of bash**: `AskUserQuestion` is a Claude Code tool invoked at the agent level, **not** a binary on `$PATH` or a shell function. Embedding `AskUserQuestion(...)` inside a fenced bash block was a category error caught in /idd-verify #47 (P1 finding 2). The agent reads the bash detection logic, branches at the agent level on `NOT_READY_COUNT > 0`, then handles the deliberation as described in prose here. Same pattern as `idd-all/SKILL.md` Phase 0.5 ask-policy interaction.
 
-When `HAS_DIAGNOSIS == 0`, the agent invokes the **AskUserQuestion** tool with this question structure (per IC_R011 canonical 3-option pattern):
+When `NOT_READY_COUNT > 0`, the agent invokes the **AskUserQuestion** tool with this question structure (per IC_R011 canonical 3-option pattern):
 
 > "Issue #${ROOT_ISSUE} 沒有 diagnosis comment。沒 diagnose 跑 chain 風險:unattended idd-diagnose Layer V 自動 proceed 可能基於 vague spec 做出 design 猜測。怎麼處理?"
 >


### PR DESCRIPTION
Refs #51

## Summary

Extract `/idd-all-chain` Step 0.4 (diagnosis-readiness check) inline bash into standalone helper script `scripts/check-diagnosis-readiness.sh`. Per Plan tier #51 D1-D5: variadic positional signature `<github-repo> <issue-number>...` returning `{"ready":[N],"not_ready":[N]}` JSON. v1 single-root invocation;ready for #46 multi-root chain extension.

Closes the prose-vs-code drift caught in `/idd-verify #47` codex P3 #9.

## Changes (2 commits)

- `e018465` feat(check-diagnosis-readiness): NEW helper script (89 lines, executable)
- `7d8027b` refactor(idd-all-chain): Step 0.4 invokes helper + chain-flow.md prose update

## Files Changed

- **NEW** `plugins/issue-driven-dev/scripts/check-diagnosis-readiness.sh` (+89, executable)
- `plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md` (+17/-14) — Step 0.4 detection block
- `plugins/issue-driven-dev/references/chain-flow.md` (+1/-1) — prose update

## Plan tier highlights

| Decision | Resolution |
|----------|-----------|
| D1 Path | Separate script (B) — matches `manifest-append.sh` precedent |
| D2 Args | Positional `<github-repo> <issue-number>...` variadic |
| D3 Output | JSON `{"ready":[N],"not_ready":[N]}` integer arrays |
| D4 Regex | `test("(?m)^## Diagnosis")` (#53 narrowing) |
| D5 Exit | 0 / 1 / 2 per `manifest-append.sh` precedent |

## Smoke Tests (7/7 PASS)

Empirically validated all cases from Plan verification matrix + 2 bonus arg validation cases. See Implementation Complete comment for full table.

## Checklist

- [x] Diagnose
- [x] Plan (Plan tier with EnterPlanMode approval gate)
- [x] Implement (2 commits)
- [ ] Verify (run `/idd-verify --pr <N>`)
- [ ] **Pending: human review of this PR + `/idd-close #51` after merge**

---

🤖 Generated by `/idd-implement` on PR path. **Do NOT add `Closes #51`** — IDD discipline requires manual `/idd-close` after merge.
