### PR TITLE
cluster-PR mode 強制 PR 與 direct-commit path 衝突：override 未文件化且 --no-pr 行為未定義

### DIFF
--- a/plugins/issue-driven-dev/references/batch-and-cluster.md
+++ b/plugins/issue-driven-dev/references/batch-and-cluster.md
@@ -130,7 +130,7 @@ Single-issue invocation (`idd-implement #19`) behavior is **unchanged**. Cluster
 
 ## Cross-references
 
-- [pr-flow.md](pr-flow.md) — PR path resolution. Cluster-PR mode always uses PR path; never direct-commit (defensive: cluster on direct-commit = stacked half-isolated changes on default branch).
+- [pr-flow.md](pr-flow.md) — PR path resolution. Cluster mode is a precondition that pre-empts the resolution algorithm and forces PR path; full semantics + override notice format in [§ Cluster mode override](pr-flow.md#cluster-mode-override). `--no-pr` / `pr_policy:"never"` colliding with cluster mode trigger an explicit override notice (mirror fork detection), then proceed as PR — no abort, no silent ignore.
 - [config-protocol.md](config-protocol.md) — `--target` / multi-repo support. All issues in a cluster MUST share one target repo (cross-repo clusters not supported).
 - IDD checklist gate (idd-close Step 0) and PR Gate (Step 1.5) apply per-issue inside the cluster.
 

--- a/plugins/issue-driven-dev/references/pr-flow.md
+++ b/plugins/issue-driven-dev/references/pr-flow.md
@@ -45,7 +45,9 @@ If `true`, override `pr_policy` regardless of config — print one-line notice (
 
 ### Cluster mode override
 
-Cluster mode — `idd-implement #34 #36 #38`, `idd-verify`, or `idd-close` invoked with **≥2 `#N` arguments** — is a precondition that pre-empts the [Resolution algorithm](#resolution-algorithm) above. Cluster mode **forces PR path**, with the same explicit override semantics as fork detection.
+Cluster mode — any IDD skill invoked with **≥2 `#N` arguments** (`idd-implement`, `idd-verify`, `idd-close`) — is a multi-issue mode where all cluster issues share one feature branch + one PR.
+
+**Path resolution is `idd-implement`'s job** — it is the only skill that resolves PR-vs-direct-commit. For `idd-implement`, cluster mode is a precondition that pre-empts the [Resolution algorithm](#resolution-algorithm) above and **forces PR path**, with the same explicit override semantics as fork detection. `idd-verify` / `idd-close` are cluster-aware but operate on the cluster's already-existing PR — they consume the path decision, they don't make it.
 
 **Why pre-empt**: a cluster is one reviewable unit (1 feature branch + 1 PR + cross-issue scope). Direct-commit on a cluster would either (a) commit N issues' changes to current branch (typically default) with no PR review gate — i.e., stacked half-isolated changes on default branch — or (b) lose the "one-PR-spans-N-issues" semantic. Both defeat cluster's purpose.
 

--- a/plugins/issue-driven-dev/references/pr-flow.md
+++ b/plugins/issue-driven-dev/references/pr-flow.md
@@ -47,7 +47,7 @@ If `true`, override `pr_policy` regardless of config — print one-line notice (
 
 Cluster mode — `idd-implement #34 #36 #38`, `idd-verify`, or `idd-close` invoked with **≥2 `#N` arguments** — is a precondition that pre-empts the [Resolution algorithm](#resolution-algorithm) above. Cluster mode **forces PR path**, with the same explicit override semantics as fork detection.
 
-**Why pre-empt**: a cluster is one reviewable unit (1 feature branch + 1 PR + cross-issue scope). Direct-commit on a cluster would either (a) commit N issues' changes to current branch (typically default) with no PR review gate, or (b) lose the "one-PR-spans-N-issues" semantic. Both defeat cluster's purpose.
+**Why pre-empt**: a cluster is one reviewable unit (1 feature branch + 1 PR + cross-issue scope). Direct-commit on a cluster would either (a) commit N issues' changes to current branch (typically default) with no PR review gate — i.e., stacked half-isolated changes on default branch — or (b) lose the "one-PR-spans-N-issues" semantic. Both defeat cluster's purpose.
 
 **Override notice**: when `--no-pr` or `pr_policy = "never"` collides with cluster mode, Phase 0.5 prints (mirror fork detection):
 
@@ -56,6 +56,8 @@ Cluster mode — `idd-implement #34 #36 #38`, `idd-verify`, or `idd-close` invok
 ```
 
 Then proceeds as PR path. **No abort, no silent ignore** — the flag is acknowledged but cannot satisfy cluster's contract. User stays informed; future single-issue invocation restores `--no-pr` / `pr_policy:"never"` honoring.
+
+**Fork + cluster co-occurrence**: both pre-emptions independently force PR path — they are not mutually exclusive. When repo is a fork AND cluster mode is invoked AND `--no-pr` (or `pr_policy=never`) is set, Phase 0.5 prints **both** notices (cluster override first, then fork) and proceeds as PR path. There is no precedence question to resolve: both pre-emptions reach the same destination (PR path), they just each independently announce their own reason.
 
 **Why not abort**: cluster's typical caller is `idd-implement #34 #36 #38 --pr` (explicit). The `--no-pr` collision case is rare (user with `pr_policy:"never"` config who happens to run cluster). Aborting would block legitimate work; the override notice lets work proceed while making the precedence visible.
 

--- a/plugins/issue-driven-dev/references/pr-flow.md
+++ b/plugins/issue-driven-dev/references/pr-flow.md
@@ -15,7 +15,7 @@ Both paths share IDD discipline: every commit references `#NNN`, no `Closes`/`Fi
 
 ## Resolution algorithm
 
-When `idd-implement` (or any IDD skill that needs to know the path) starts, resolve in this order:
+When `idd-implement` (or any IDD skill that needs to know the path) starts, resolve in this order. **Cluster mode (≥2 `#N` invocations) is a precondition that pre-empts this table — see [Cluster mode override](#cluster-mode-override) below.**
 
 ```
 1. --pr flag                     → PR path (per-invocation)
@@ -42,6 +42,26 @@ IS_FORK=$(gh repo view "$GITHUB_REPO" --json isFork -q .isFork)
 ```
 
 If `true`, override `pr_policy` regardless of config — print one-line notice ("repo is a fork → PR path enforced") and proceed.
+
+### Cluster mode override
+
+Cluster mode — `idd-implement #34 #36 #38`, `idd-verify`, or `idd-close` invoked with **≥2 `#N` arguments** — is a precondition that pre-empts the [Resolution algorithm](#resolution-algorithm) above. Cluster mode **forces PR path**, with the same explicit override semantics as fork detection.
+
+**Why pre-empt**: a cluster is one reviewable unit (1 feature branch + 1 PR + cross-issue scope). Direct-commit on a cluster would either (a) commit N issues' changes to current branch (typically default) with no PR review gate, or (b) lose the "one-PR-spans-N-issues" semantic. Both defeat cluster's purpose.
+
+**Override notice**: when `--no-pr` or `pr_policy = "never"` collides with cluster mode, Phase 0.5 prints (mirror fork detection):
+
+```
+→ cluster mode (N issues) → PR path enforced (overriding --no-pr / pr_policy=never)
+```
+
+Then proceeds as PR path. **No abort, no silent ignore** — the flag is acknowledged but cannot satisfy cluster's contract. User stays informed; future single-issue invocation restores `--no-pr` / `pr_policy:"never"` honoring.
+
+**Why not abort**: cluster's typical caller is `idd-implement #34 #36 #38 --pr` (explicit). The `--no-pr` collision case is rare (user with `pr_policy:"never"` config who happens to run cluster). Aborting would block legitimate work; the override notice lets work proceed while making the precedence visible.
+
+**Single-issue invocation behavior is unchanged** — the cluster carve-out only fires on ≥2 `#N`. Backward compatibility preserved.
+
+Cross-reference: full cluster semantics in [batch-and-cluster.md](batch-and-cluster.md).
 
 ### `pr_policy` config field
 

--- a/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
@@ -46,7 +46,7 @@ allowed-tools:
 
 `idd-implement #34 #36 #38 --pr` 觸發 cluster-PR mode：3 個 issue 共用 1 個 feature branch + 1 個 PR，但每個 commit 仍以 `Refs #N`（可多）紀律標示對應 issue。Strategy-level TaskList 從各 issue 的 diagnosis 聚合，scope guard 仍逐 issue 檢查。
 
-完整契約見 [batch-and-cluster.md](../../references/batch-and-cluster.md)。Cluster-PR mode 強制 PR path（不接受 `--no-pr`），Branch 命名 `idd/cluster-{slug}`，PR 標題前綴 `cluster:`。
+完整契約見 [batch-and-cluster.md](../../references/batch-and-cluster.md)。Cluster-PR mode 強制 PR path:`--no-pr` 或 `pr_policy=never` 撞 cluster 時,Phase 0.5 印 explicit override notice(`→ cluster mode (N issues) → PR path enforced (overriding --no-pr / pr_policy=never)`,mirror fork detection 既有 pattern)後 proceed as PR mode — 不 abort、不 silent ignore。完整 resolution semantics 見 [pr-flow.md § Cluster mode override](../../references/pr-flow.md#cluster-mode-override)。Branch 命名 `idd/cluster-{slug}`,PR 標題前綴 `cluster:`。
 
 實用情境：04/27 那種「7 個 issue 分成 Docs + Sanitizer-hardening 2 個 themed PR」的工作流。Single-issue 模式（`idd-implement #19`）行為不變。
 

--- a/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
@@ -97,6 +97,8 @@ TaskCreate(name="sister_bug_sweep", description="Step 5.7: review session log + 
 完整 resolution algorithm 見 [references/pr-flow.md](../../references/pr-flow.md)。簡述:
 
 ```
+0. Cluster mode (≥2 #N args)     → pre-empts entire table; PR path forced
+                                    (see pr-flow.md § Cluster mode override)
 1. --pr flag                     → PR path
 2. --no-pr flag                  → direct-commit path
 3. gh repo view --json isFork    → 若 true,強制 PR path(無法 push 到 upstream)
@@ -106,14 +108,18 @@ TaskCreate(name="sister_bug_sweep", description="Step 5.7: review session log + 
 ```
 
 ```bash
-# 1. Parse flag
+# 1. Parse flag + count issue args (cluster mode = ≥2 #N)
 PR_FLAG=""  # "pr" / "no-pr" / ""
+ISSUE_COUNT=0
 for arg in "$@"; do
     case "$arg" in
-        --pr)    PR_FLAG="pr" ;;
-        --no-pr) PR_FLAG="no-pr" ;;
+        --pr)     PR_FLAG="pr" ;;
+        --no-pr)  PR_FLAG="no-pr" ;;
+        \#[0-9]*) ISSUE_COUNT=$((ISSUE_COUNT + 1)) ;;
     esac
 done
+CLUSTER_MODE="false"
+[ "$ISSUE_COUNT" -ge 2 ] && CLUSTER_MODE="true"
 
 # 2. Fork check
 IS_FORK=$(gh repo view "$GITHUB_REPO" --json isFork -q .isFork 2>/dev/null || echo "false")
@@ -121,8 +127,19 @@ IS_FORK=$(gh repo view "$GITHUB_REPO" --json isFork -q .isFork 2>/dev/null || ec
 # 3. Config policy
 PR_POLICY=$(jq -r '.pr_policy // "ask"' "$CONFIG_PATH" 2>/dev/null || echo "ask")
 
-# 4. Resolve
-if [ "$PR_FLAG" = "pr" ]; then
+# 4. Resolve (cluster mode is a precondition that pre-empts the table; see pr-flow.md § Cluster mode override)
+if [ "$CLUSTER_MODE" = "true" ]; then
+    PATH_CHOICE="pr"
+    # If --no-pr or pr_policy=never collides, print explicit override notice (mirror fork detection)
+    OVERRIDE_SRC=""
+    [ "$PR_FLAG" = "no-pr" ] && OVERRIDE_SRC="--no-pr"
+    [ "$PR_POLICY" = "never" ] && OVERRIDE_SRC="${OVERRIDE_SRC:+$OVERRIDE_SRC / }pr_policy=never"
+    if [ -n "$OVERRIDE_SRC" ]; then
+        echo "→ cluster mode ($ISSUE_COUNT issues) → PR path enforced (overriding $OVERRIDE_SRC)"
+    fi
+    # If fork ALSO detected, print fork notice too (both pre-emptions independently force PR)
+    [ "$IS_FORK" = "true" ] && echo "→ Repo is a fork; PR path enforced."
+elif [ "$PR_FLAG" = "pr" ]; then
     PATH_CHOICE="pr"
 elif [ "$PR_FLAG" = "no-pr" ]; then
     PATH_CHOICE="no-pr"


### PR DESCRIPTION
Refs #96

## Summary

Documents `cluster mode` as a precondition that pre-empts the `pr-flow.md` resolution algorithm, with explicit override notice (mirror fork detection) when `--no-pr` / `pr_policy:"never"` collides with cluster mode. Implements **Option A** from the diagnosis (user-selected in `idd-all` session).

The cluster-PR-mode-vs-`--no-pr` rule was previously split across 3 files (`pr-flow.md` algorithm table didn't mention it; `idd-implement` SKILL line 49 said "doesn't accept --no-pr" without specifying behavior; `batch-and-cluster.md` line 133 stated the rule but in cross-references). Three files contradicted; behavior on collision was undefined.

## Changes (1 commit, 3 files, +23/-3)

- `references/pr-flow.md` — add `### Cluster mode override` subsection + algorithm-table preface note
- `references/batch-and-cluster.md` — line 133 → pointer to pr-flow.md new section
- `skills/idd-implement/SKILL.md` — line 49 stub → spec'd behavior with explicit override notice format

## Decision: Option A

Diagnosis surfaced 3 candidate approaches; user picked **A** (maintain forced PR, but explicit + consistent):

- Smallest change (3-file doc tweak)
- Mirrors existing fork detection pattern (consistency principle)
- Backward-compatible (single-issue invocation behavior unchanged; cluster carve-out only fires on ≥2 `#N`)

Options B (cluster accepts `--no-pr` and degrades to shared branch) and C (AskUserQuestion on collision) deferred — re-open as follow-up if A proves insufficient in practice.

## Checklist

- [x] Diagnose ([comment 4483898985](https://github.com/PsychQuant/issue-driven-development/issues/96#issuecomment-4483898985))
- [x] Implement (3 commits: `cbe6f5d` R1 doc + `5351116` R2 bash + `04c51cb` R3 doc fix)
- [x] Verify — 6-AI × 2 rounds: R1 CONDITIONAL → R2 6/6 PASS ([R2 master](https://github.com/PsychQuant/issue-driven-development/pull/99#issuecomment-4484127782))
- [ ] **Pending: human review of this PR + `/idd-close #96` after merge**

## Related

- Diagnose comment: [#issuecomment-4483898985](https://github.com/PsychQuant/issue-driven-development/issues/96#issuecomment-4483898985)
- Implementation Plan: [#issuecomment-4483913507](https://github.com/PsychQuant/issue-driven-development/issues/96#issuecomment-4483913507)
- Implementation Complete: [#issuecomment-4483920623](https://github.com/PsychQuant/issue-driven-development/issues/96#issuecomment-4483920623)
- Sister issue context: PR #94 (auto-close-trap cluster) surfaced this design conflict; PR #98 (squash-commit-body trap) merged separately

---
Generated by IDD `/idd-all 96`. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves) — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.

