### PR TITLE
docs: concurrent-session isolation rule (worktree-default + don't-yank) (#165)

### DIFF
--- a/plugins/issue-driven-dev/references/pr-flow.md
+++ b/plugins/issue-driven-dev/references/pr-flow.md
@@ -131,6 +131,25 @@ If branch already exists:
 git checkout -b "$BRANCH"
 ```
 
+### Concurrent-session isolation (worktree) — #947
+
+The shared working tree is single-occupant. When two `/idd` sessions run against the same clone, in-tree branch switching collides: the second session's branch acquisition pulls the tree out from under the first, and any "clear the tree first" step (`git stash` + `git checkout`) **parks the first session's uncommitted/untracked WIP** — silent data loss. Reproduced live (ai_martech_global_scripts #941↔#942): a concurrent session manually stashed + branch-switched a tree that held another session's WIP, yanking it. Note the root cause was **agentic** — the documented clean-tree abort below already prevents the flow from yanking; the collision came from a session manually clearing the tree to "make room".
+
+**Rules (PR path):**
+
+1. **Default to an isolated `git worktree`, not in-tree `checkout -b`.** Provision the feature branch in its own working directory so concurrent PR-path sessions never share one tree:
+   ```bash
+   WORKTREE="${WORKTREE_ROOT:-$(git -C "$CWD" rev-parse --git-dir)/idd-worktrees}/${BRANCH##*/}"
+   git -C "$CWD" worktree add "$WORKTREE" -b "$BRANCH" "$DEFAULT_BRANCH"
+   CWD="$WORKTREE"   # all subsequent git/gh ops reuse the existing `git -C "$CWD"` plumbing
+   # ... after the PR is opened (or the run aborts): git worktree remove "$WORKTREE"
+   ```
+   The existing `--cwd` cross-repo substitution (`git -C "$CWD"`) already routes every downstream step to the worktree — no other step changes. Repo-specific **gitignored** symlinks (e.g. a `00_principles` symlink) are NOT recreated in a fresh worktree; provide them via a repo-level setup hook if the run's tests need them, otherwise those tests skip (acceptable for codegen-only helpers).
+
+2. **The clean-tree + on-default abort guard is the floor — never bypass it by manually clearing the tree.** A session MUST NOT `git stash` / `git checkout` a shared working tree that may hold another session's WIP to "make room" for its own branch. If the tree is dirty or on another `idd/*` branch: use a worktree (rule 1), or abort and let the human decide — do **not** stash-and-switch.
+
+3. **Single-occupant fallback.** Where worktrees are unavailable, the documented clean-tree/on-default abort stands: refuse rather than yank.
+
 ### PR creation (after verify PASS)
 
 ```bash

--- a/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
@@ -289,6 +289,11 @@ DEFAULT=$(gh repo view "$GITHUB_REPO" --json defaultBranchRef -q .defaultBranchR
 CURRENT=$(git -C "$CWD" branch --show-current)
 [ "$CURRENT" = "$DEFAULT" ] || abort "Cluster branch must start from $DEFAULT (currently on $CURRENT)"
 
+# Concurrent-session isolation (#947): the abort above is the floor — refuse, don't yank.
+# Prefer an isolated `git worktree add` for the cluster branch so concurrent /idd runs
+# never share one tree; NEVER manually stash+checkout a shared tree that may hold another
+# session's WIP. Full rule: references/pr-flow.md → "Concurrent-session isolation".
+
 # Build cluster branch name — dispatch on N
 TITLE=$(gh issue view "$LOWEST_ROOT" -R "$GITHUB_REPO" --json title -q .title)
 SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \

--- a/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
@@ -200,6 +200,8 @@ fi
 
 If branch already exists from a prior aborted run: AskUserQuestion (checkout / `${EXPECTED}-2` suffix / abort).
 
+> **Concurrent-session isolation (#947)**: the `abort` branch above is the floor — it refuses rather than yanking when the tree is on another branch. **Prefer an isolated `git worktree`** for PR-path branch acquisition so concurrent `/idd` sessions never share one tree (set `CWD` to the worktree; the existing `git -C "$CWD"` plumbing routes the rest of the flow). And **never** manually `git stash` / `git checkout` a shared tree that may hold another session's WIP to "make room" — that is the silent-data-loss path reproduced in #941↔#942 (the yank was an agentic manual action, not this documented flow). Full rule + worktree snippet: [`references/pr-flow.md`](../../references/pr-flow.md) → "Concurrent-session isolation".
+
 #### If direct-commit path: print notice, stay on current branch
 
 ```bash


### PR DESCRIPTION
Refs #165

## Summary
Codify the **Option A** decision from ai_martech_global_scripts#947: a concurrent-session isolation rule for PR-path branch acquisition. Concurrent /idd sessions collided on a shared working tree (origin: #941<->#942) — a session manually stash+checkout-ed a tree holding another session's WIP. Root cause was **agentic** (the documented Phase 0.5 already aborts on dirty/non-default); the fix is the missing isolation primitive + an explicit rule.

## Changes (doc/behavior-spec, +26 lines, 3 files)
- `references/pr-flow.md`: new **Concurrent-session isolation (worktree)** section — worktree snippet (reuses existing `git -C $CWD` plumbing), abort-is-the-floor, never-manually-yank-a-shared-tree, gitignored-symlink caveat.
- `idd-implement` Phase 0.5 + `idd-all-chain` cluster-branch: guard pointers to the rule.
- `idd-all` inherits via its existing pr-flow.md reference.

## Out of scope (follow-up)
Full mechanization of worktree-default into every skill's Phase 0.5 **bash** (auto-provision + auto-cleanup, $CWD rewrite across the flow) — the snippet is documented; wiring it into bash is a larger ergonomic change. The behavior-spec rule here already prevents recurrence.

## Verify
Markdown/behavior-spec only; no code/tests. Review the rule wording + that idd-implement/idd-all-chain pointers resolve to the pr-flow.md section.

---
Do NOT add a GitHub auto-close trailer. The tracking issue (165) gets a manual closing note after merge — body kept free of a close-keyword+number link so GitHub won't auto-close it.