### PR TITLE
feat: third-party clone setup — detection + non-polluting config placement (#192)

### DIFF
--- a/openspec/changes/add-third-party-clone-setup/.openspec.yaml
+++ b/openspec/changes/add-third-party-clone-setup/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-06-26
+created_by: che cheng <kiki830621@gmail.com>
+created_with: claude

--- a/openspec/changes/add-third-party-clone-setup/design.md
+++ b/openspec/changes/add-third-party-clone-setup/design.md
@@ -78,7 +78,7 @@ third-party 預設一併寫 `pr_policy: never`（無 push 權 → local direct-c
 - 處理 git「parent-dir-excluded」quirk（單行 `!` 例外在父目錄被 exclude 時無效 → 需 carve-out 鏈；#55 已踩過並驗證 5-line 解法）。
 - **方向**（re-include vs exclude）與**目標檔**（`.gitignore` vs `.git/info/exclude`）由 caller 以參數帶入；primitive 不假設任一方向。
 
-**#55 regression 保證**：refactor 後 Stage 4.5 對 `.gitignore` 寫入的 byte 輸出必須與 refactor 前**位元等價**（用既有 #55 test fixtures 對拍）。primitive 抽取是純 refactor，不改 #55 observable behavior。
+**#55 regression 保證（amended — apply 時發現 byte-equivalence 不可行）**：byte-equivalence 證實**不可能** —— helper 用 BEGIN/END sentinel，舊 #55 block 是 single-marker + rationale-comments 格式；要 byte-equivalent 就得讓 generic helper 複製 #55 的特定格式，抹殺抽取意義。改採 **behavior-equivalence**：refactor 後 `git check-ignore` 結果與 refactor 前**完全一致**（run-log 變 trackable、sibling 仍 ignored、bare `.claude/` 移除、gate options/summary/`JSONL_GITIGNORE_DECISION` 不變），外加**一次性遷移**舊格式 block（偵測舊 marker → strip → helper 寫新 sentinel，不重複）。gate options 不變、user 內容保留。由 `scripts/tests/stage45-carveout-migration/test.sh`（13 assertions）驗證。
 
 ### D5: idd-config init / idd-all 對齊
 

--- a/openspec/changes/add-third-party-clone-setup/design.md
+++ b/openspec/changes/add-third-party-clone-setup/design.md
@@ -1,0 +1,149 @@
+## Context
+
+`idd-issue` Step 0.5.E（fork-aware detection）是 target-resolution 的最後一層（config-protocol mechanism 5，`git remote fallback`）。現有兩條 branch：E1（non-fork → 直接用 origin、不問）、E2（fork → 3-option）。
+
+「clone 別人的 repo」（reference / 教學 / 研究素材，無 push 權）是 non-fork，落進 E1 → 靜默把 issue 導向原作者公開 repo + 把 `.claude/.idd/` config 寫進對方 working tree。GitHub 公開 repo 任何登入者都能開 issue，所以這是個**真會誤污染**的路徑，而非理論問題。
+
+本 change 補上第三條 branch，並把「IDD config 不污染對方 repo」的機制（`.git/info/exclude`）內建為偵測到 third-party 時的預設建議。
+
+## Goals / Non-Goals
+
+### Goals
+
+- Step 0.5.E 偵測 third-party clone 並主動給 routing + config-placement 建議。
+- third-party 預設用 `.git/info/exclude`（per-clone、不 commit/push、不動對方 tracked 檔）擋 IDD config。
+- 抽共用 ignore-block writer primitive，消除 #55 與本 feature 的重複邏輯。
+
+### Non-Goals
+
+- 自動建 tracking repo（保持零 outward action）。
+- 改 E1 / E2 既有行為。
+- 把兩種 ignore 操作併成單一 function。
+
+## Decisions
+
+### D1: 偵測判準 = hybrid（owner-mismatch pre-filter → push-permission probe）
+
+```
+owner_self  = gh api user --jq .login
+origin_owner = <parsed from origin>
+if origin_owner == owner_self:        → 你自己的 repo（E1 路徑，零額外 API）
+else:
+    push = gh api repos/{o}/{r} --jq .permissions.push   # 僅在不符時才打這支
+    if push == true:   → 你有 push 權（org repo / collaborator）→ E1-like，不算 third-party
+    else:              → third-party clone → 新 branch
+```
+
+**為什麼 hybrid 不是單一判準**：
+
+- 純 owner-mismatch → false positive：你有 push 權的 org repo（owner=org≠你）會被誤判 third-party。
+- 純 push-permission → 每次 first-run（含你自己的 repo common case）都多一支 API call + 需 auth scope。
+- hybrid：common case（自己的 repo）零額外 API；只有 owner 不符才付一次 probe 成本，且精準回答「我能不能寫」。
+
+> Fork（E2）必須**先於** third-party 判斷 —— fork 也是 owner-mismatch + 常無 push 權，但 fork 有自己的 upstream 語意（contributor / customization / divergent）。順序：E2 fork → 新 third-party branch → E1。
+
+### D2: 偵測到時 = 3-option AskUserQuestion（不自動選）
+
+| 選項 | target | 寫入 |
+|---|---|---|
+| Upstream（原作者 repo） | origin | config `github_repo=origin`；**警示公開可見** |
+| 自己的 tracking repo | 使用者給的 `--target you/repo` | config `github_repo=you/repo` |
+| Local-only | — | 不開 GitHub issue（degrade 提示） |
+
+routing 是使用者意圖，猜會錯一半 → 強制問（與 fork E2 同構）。tracking repo **只接受既有 repo**（`--target` / 手填），不 `gh repo create`。
+
+### D3: Config-placement × ignore-mechanism 矩陣
+
+| 情境 | config 放哪 | ignore 機制 |
+|---|---|---|
+| 自己的 repo | `.claude/.idd/local.json`，可 commit 或全域忽略 | 視團隊慣例 |
+| **third-party clone** | `.claude/.idd/local.json`（local） | **`.git/info/exclude`** 擋 `.claude/.idd/`（per-clone、不 commit/push） |
+| monorepo / 巢狀 | walk-up config 放非 git 上層 | 同上 |
+
+third-party 預設一併寫 `pr_policy: never`（無 push 權 → local direct-commit，避免 `idd-implement` push 失敗）。**絕不**改對方 tracked `.gitignore`（那等於在對方 history 疊 commit = 污染）。
+
+### D4: 共用 helper = 共同 primitive，不是單一 function（CRITICAL）
+
+#55（Stage 4.5）與本 feature 是**方向相反**的 ignore 操作：
+
+| | #55 carve-out | 本 feature exclude |
+|---|---|---|
+| 目標檔 | **tracked `.gitignore`** | **untracked `.git/info/exclude`** |
+| 方向 | **re-include**（把被 ignore 的 jsonl 拉回可 commit） | **exclude**（把 IDD config 擋掉） |
+| 是否進 git | 是（要 commit `.gitignore` 變更） | 否（`.git/` 內，永不 commit/push） |
+
+→ 抽出的 primitive 是 `write_idempotent_ignore_block(target_file, marker, lines)`：
+
+- marker-delimited block（重跑 idempotent，靠 marker comment 偵測 + state-machine 替換 stale block，沿用 #55 已驗證的 awk 邏輯）。
+- 處理 git「parent-dir-excluded」quirk（單行 `!` 例外在父目錄被 exclude 時無效 → 需 carve-out 鏈；#55 已踩過並驗證 5-line 解法）。
+- **方向**（re-include vs exclude）與**目標檔**（`.gitignore` vs `.git/info/exclude`）由 caller 以參數帶入；primitive 不假設任一方向。
+
+**#55 regression 保證**：refactor 後 Stage 4.5 對 `.gitignore` 寫入的 byte 輸出必須與 refactor 前**位元等價**（用既有 #55 test fixtures 對拍）。primitive 抽取是純 refactor，不改 #55 observable behavior。
+
+### D5: idd-config init / idd-all 對齊
+
+- `/idd-config init` 偵測 third-party 時，呈現同 D2 的 3-option，並依 D3 寫 config + `.git/info/exclude`。
+- `idd-all` Phase 0.5 mode resolution：偵測到 third-party（且 config 未顯式設 pr_policy）→ 套用 `pr_policy: never` 預設（位階同 fork → PR override，但方向相反）。
+
+## Implementation Contract
+
+### Observable Behavior
+
+1. 在 third-party clone（owner 不符 + 無 push 權）首跑 `/idd-issue` → 出現 3-option AskUserQuestion；選 tracking repo → issue 開到該 repo，`.claude/.idd/` 進 `.git/info/exclude`，`git status` 乾淨。
+2. 在自己的 repo / 有 push 權的 org repo 首跑 `/idd-issue` → 行為與今日 E1 完全相同（無新 prompt、無額外 API 在 owner 相符時）。
+3. fork 首跑 → 行為與今日 E2 完全相同。
+4. Stage 4.5 #55 carve-out → 輸出與 refactor 前位元等價。
+
+### Acceptance Criteria
+
+- [ ] third-party 偵測：owner-mismatch + push=false → 觸發新 branch；owner 相符 OR push=true → 不觸發。
+- [ ] fork 優先於 third-party（fork repo 不被誤判為 third-party）。
+- [ ] 3-option routing 寫對 config + `.git/info/exclude` + `pr_policy: never`。
+- [ ] E1 / E2 backward compat：既有測試全綠。
+- [ ] #55 carve-out refactor：位元等價（fixture 對拍）。
+- [ ] `idd-config init` + `idd-all` Phase 0.5 對齊。
+
+### Out of Scope
+
+- tracking repo 自動建立。
+- 「co-maintained / vendored read-only」灰色情境的精細分流。
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| push-permission probe 多一支 API + 需 auth scope | hybrid pre-filter：只有 owner 不符才打；owner 相符（common case）零額外 API |
+| 與 fork E2 double-prompt | 嚴格排序 E2 → third-party → E1；third-party 判斷在 `IS_FORK=false` 分支內 |
+| #55 refactor 改壞既有行為 | 位元等價對拍 + 既有 fixtures；primitive 為純抽取 |
+| `.git/info/exclude` re-clone 後消失 | 文件化此性質（per-clone 本質）；偵測在每次 first-run 都會重跑，re-clone 後重設 |
+| git parent-dir-excluded quirk | 沿用 #55 已驗證 5-line carve-out 邏輯，不重新推導 |
+
+## Migration Plan
+
+### Deploy
+
+純 additive：新 branch 在 `IS_FORK=false` 內插入 third-party 判斷；helper 抽取為 refactor。無 schema migration。Bump `idd-issue` / `idd-config` / `idd-all` plugin minor version。
+
+### Rollback
+
+移除 third-party branch → 回到 E1/E2 兩分支行為；helper 抽取可獨立 revert（#55 改回 inline）。已寫入使用者 repo 的 `.git/info/exclude` 規則無害（per-clone、不影響對方），rollback 不需清理。
+
+### Backward Compat
+
+- E1（你自己的新 repo）silent-write 不變。
+- E2（fork）3-option 不變。
+- 既有已寫好的 config（含本 session 在 kaochenlong repo 的手動 setup）被偵測為「config 已存在」→ 走 mechanism 4，不重跑偵測。
+
+## Open Questions
+
+### Q1: push-permission probe 的 auth scope 失敗如何處理？
+
+若 `gh api repos/{o}/{r}` 因 scope / rate-limit 失敗 → fail-open（當作 third-party、給建議）還是 fail-closed（當作非 third-party、走 E1）？傾向 **fail-safe = 當 third-party 並提示**（寧可多問一次，不要靜默污染）。propose review 時定。
+
+### Q2: 「co-maintained / vendored read-only」灰色地帶（residue）
+
+push permission 是機械 proxy，但「不真正屬於你的 repo」意圖更廣 —— 你共同維護但非建立的 repo（有 push 權卻可能不想污染）、只讀 clone 的 vendored dependency。本 change 用 push permission 一刀切，灰色情境留給 future signal（如顯式 `--third-party` flag）。**標記為 residue，不靜默吞掉。**
+
+### Q3: tracking repo 是否接 config-protocol `candidates` 機制？
+
+「自己的 tracking repo」選項可否記住跨多個 third-party clone 共用一個預設 tracking repo（接既有 `candidates`）？本 change 先做單次 `--target`/config；candidates 整合列為 follow-up。

--- a/openspec/changes/add-third-party-clone-setup/discussion.md
+++ b/openspec/changes/add-third-party-clone-setup/discussion.md
@@ -1,0 +1,39 @@
+# Discussion — add-third-party-clone-setup
+
+Audit trail of the alignment that produced this change (per IDD MANIFESTO). Source: `/idd-diagnose #192` → spectra-discuss, 2026-06-26.
+
+## Origin
+
+GitHub issue #192 (`PsychQuant/issue-driven-development`). Filed after a live incident: user cloned `kaochenlong/spectra-app` + `sherly-app` (HTTPS, no push permission) as reference material, and had to manually figure out `.claude/.idd/local.json` (`pr_policy: never`) + `.git/info/exclude` to avoid polluting the original author's repo. The manual derivation should be built into IDD.
+
+## Diagnosis verdict (idd-diagnose #192)
+
+- Type: feature
+- Complexity: **Spectra** — modifies `config-protocol.md` (normative SSOT for all idd-* target resolution) + `idd-issue` Step 0.5.E documented behavior contract (Layer 2 met); modifies normative spec behavior + affects 2+ skills + architectural decision future engineers inherit (Layer 3 met).
+- Conflict Class: `C_shared_module_coord` (shared `config-protocol.md` + `idd-issue` Step 0.5.E).
+- Layer V vagueness: not triggered (V1=2, V4=3).
+
+## Aligned decisions (spectra-discuss)
+
+The 3 open questions from diagnosis were resolved via choice-first AskUserQuestion:
+
+1. **Detection criterion** → **hybrid** (owner-mismatch cheap pre-filter → push-permission probe only on mismatch). Rejected: pure owner-mismatch (false-positives org repos you can push to), pure push-probe (API cost on every own-repo first-run).
+2. **Tracking repo** → **`--target` / config only, no auto-create** (zero outward action).
+3. **Scope** → **full**: includes extracting a shared `.git/info/exclude` / `.gitignore` ignore-block writer primitive shared with Stage 4.5 #55.
+
+## Key design subtlety surfaced
+
+#55 (Stage 4.5) and this feature are **opposite-direction** ignore operations:
+
+- #55: re-include a path in **tracked `.gitignore`** (so the jsonl run-log can be committed).
+- #192: exclude a path in **untracked `.git/info/exclude`** (so IDD config never pollutes upstream).
+
+→ The shared helper must be a **common primitive** (idempotent marker-delimited block writer + git parent-dir-excluded handling), parameterized by target file + direction — NOT forced into a single function. design.md D4 captures this with a byte-equivalence regression guarantee for #55.
+
+## Residue (NSQL §4.6)
+
+"What counts as a third-party clone worth special-casing" is partly a values judgment that push-permission cannot fully capture (e.g. a repo you co-maintain but did not create, or a read-only vendored dependency). The spec picks a mechanical proxy (push permission); the broader intent ("don't pollute repos that aren't really yours") is flagged in design.md Open Questions Q2, not silently dropped.
+
+## Provenance
+
+- Discuss + propose conducted manually (not via `spectra` CLI slash command) because the driving session's cwd was outside the dev clone. Artifacts authored directly into `openspec/changes/`; `.spectra/spectra.db` change-state NOT updated by this manual pass — run `spectra` CLI sync if DB consistency is required before apply.

--- a/openspec/changes/add-third-party-clone-setup/proposal.md
+++ b/openspec/changes/add-third-party-clone-setup/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+IDD 的 target-resolution（`idd-issue` Step 0.5.E）目前只有兩條 branch：
+
+| Branch | 條件 | 行為 |
+|---|---|---|
+| **E1** | `IS_FORK=false` | 直接用 origin、寫 config、**不詢問** |
+| **E2** | `IS_FORK=true` + upstream | 3-option AskUserQuestion（upstream / own fork / both） |
+
+「**clone 別人的 repo 當參考 / 教學 / 研究素材**」（origin owner ≠ 你、不是你的 fork、無 push 權）是 non-fork → 落進 **E1** → issue 預設導向**原作者的公開 repo**（GitHub 公開 repo 任何登入者都能開 issue），且 IDD config 被寫進對方 working tree，**零** non-pollution guidance。使用者得自己想到用 `.git/info/exclude` 才不會把工具檔留在對方 repo。
+
+**Concrete incident**（本 change 起源，2026-06-26）：使用者 clone `kaochenlong/spectra-app` + `sherly-app`（HTTPS、無 push 權）當參考。手動設了 `.claude/.idd/local.json`（`pr_policy: never`）+ 在 `.git/info/exclude` 擋 `.claude/.idd/`，才避免污染原作者 repo。這套手動推導應內建為 IDD guidance。
+
+**GitHub-side tracker**: #192
+
+## What Changes
+
+新增 Step 0.5.E 第三條 branch（third-party clone）+ 抽共用 ignore-block helper：
+
+1. **Patch `idd-issue` Step 0.5.E** — 加 third-party detection（hybrid：owner-mismatch pre-filter → push-permission probe），偵測到 → 3-option routing（upstream / tracking repo / local-only），**排在 fork E2 之後、E1 之前**。
+2. **Patch `references/config-protocol.md`** — mechanism 5 加 third-party 偵測條款 + 文件化「config-placement × ignore」決策矩陣。
+3. **Patch `idd-config` init** — `/idd-config init` 提供同款 third-party setup。
+4. **Patch `idd-all` Phase 0.5** — third-party clone → `pr_policy: never` 預設（無 push 權 → local direct-commit）。
+5. **Extract shared `git-ignore-block-writer` helper** — idempotent marker-delimited block writer primitive，供 Stage 4.5 #55 carve-out（在 tracked `.gitignore` **re-include**）與本 feature 的 exclude writer（在 untracked `.git/info/exclude` **exclude**）共用；#55 既有行為**不退化**。
+
+## Non-Goals
+
+- **不自動建 tracking repo**（無 `gh repo create`）— 使用者用 `--target` / config 指定既有 repo。
+- **不改變 fork（E2）行為** — third-party 排在 fork 之後，fork 邏輯原封不動。
+- **不改 E1（你自己的新 repo）的 silent-write** — backward compat，common case 零退化。
+- **不把 #55 與 third-party 的 ignore 操作併成單一 function** — 兩者方向相反（re-include vs exclude），只抽共同 primitive。
+- **不解「co-maintained / vendored read-only」的灰色地帶** — 偵測用機械 proxy（push permission），灰色情境列為 residue（見 design Open Questions）。
+
+## Capabilities
+
+### New Capabilities
+
+- `idd-third-party-clone-detection`: `idd-issue` Step 0.5.E 新增 third-party clone branch — hybrid 偵測（owner-mismatch cheap pre-filter → push-permission probe），偵測到時走 3-option routing（upstream / 自己的 tracking repo via `--target`+config / local-only），排序在 fork E2 之後、E1 之前；`/idd-config init` parity；backward compat 保證 E1 與 fork 路徑不變。
+- `idd-third-party-config-placement`: 文件化並實作 config-placement × ignore-mechanism 矩陣 — third-party clone 預設 `.git/info/exclude` 擋 `.claude/.idd/` + `pr_policy: never`；`idd-all` Phase 0.5 對 third-party 套用 `pr_policy: never` 預設；config-protocol mechanism 5 收錄偵測條款。
+- `git-ignore-block-writer-helper`: 抽出一個 idempotent、marker-delimited 的 git ignore-block writer primitive，以參數區分目標檔（`.gitignore` vs `.git/info/exclude`）與方向（re-include vs exclude）+ 處理 git「parent-dir-excluded」quirk；Stage 4.5 #55 carve-out 重構為呼叫此 primitive，行為位元等價。

--- a/openspec/changes/add-third-party-clone-setup/specs/git-ignore-block-writer-helper/spec.md
+++ b/openspec/changes/add-third-party-clone-setup/specs/git-ignore-block-writer-helper/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: shared idempotent git ignore-block writer primitive
+
+The plugin SHALL provide a single shared primitive that writes an idempotent, marker-delimited block of git ignore patterns to a caller-specified target file, parameterized by direction (re-include vs exclude). Both the Stage 4.5 (#55) `.gitignore` carve-out and the third-party `.git/info/exclude` writer SHALL use this primitive.
+
+#### Scenario: idempotent re-run via marker
+
+- **WHEN** the primitive is invoked twice with the same marker, target file, and lines
+- **THEN** the second invocation SHALL NOT duplicate the block
+- **AND** the resulting file SHALL contain exactly one copy of the marker-delimited block
+
+#### Scenario: stale block upgrade-in-place
+
+- **WHEN** the target file contains a block with the same marker but different lines (a stale earlier version)
+- **THEN** the primitive SHALL replace the stale block in place (delete-then-append) without disturbing surrounding user content
+- **AND** SHALL preserve any non-block lines (blank lines / user comments) adjacent to the block
+
+#### Scenario: exclude direction targets .git/info/exclude
+
+- **WHEN** the primitive is called with direction=exclude and target=`.git/info/exclude` and pattern `.claude/.idd/`
+- **THEN** it SHALL append/update the block in `.git/info/exclude`
+- **AND** the written rules SHALL cause `git check-ignore` to report `.claude/.idd/local.json` as ignored
+
+#### Scenario: re-include direction handles parent-dir-excluded quirk
+
+- **WHEN** the primitive is called with direction=re-include and target=`.gitignore` for a path whose parent directory is excluded
+- **THEN** it SHALL emit the multi-line carve-out chain (parent re-include → re-exclude contents → re-include the target path) rather than a single `!path` line
+- **AND** the re-included path SHALL become trackable (`git check-ignore` reports it as NOT ignored)
+
+### Requirement: Stage 4.5 carve-out refactor preserves behavior
+
+The Stage 4.5 (#55) `.gitignore` carve-out logic SHALL be refactored to call the shared primitive, with byte-equivalent output to the pre-refactor implementation.
+
+#### Scenario: refactored carve-out is byte-equivalent
+
+- **WHEN** the refactored Stage 4.5 carve-out runs against the existing #55 test fixtures (root `.gitignore`, `.git/info/exclude`, global `core.excludesfile`, and stacked combinations)
+- **THEN** the resulting `.gitignore` content SHALL be byte-equivalent to the pre-refactor output for every fixture
+- **AND** all existing #55 scenarios (add-exception / skip-commit / abort / nested-gitignore) SHALL continue to pass
+
+#### Scenario: refactor does not change #55 observable surface
+
+- **WHEN** Stage 4.5 dispatches the gate decision after the refactor
+- **THEN** the gate's user-facing options, summary lines, and `JSONL_GITIGNORE_DECISION` values SHALL be unchanged

--- a/openspec/changes/add-third-party-clone-setup/specs/git-ignore-block-writer-helper/spec.md
+++ b/openspec/changes/add-third-party-clone-setup/specs/git-ignore-block-writer-helper/spec.md
@@ -30,15 +30,24 @@ The plugin SHALL provide a single shared primitive that writes an idempotent, ma
 
 ### Requirement: Stage 4.5 carve-out refactor preserves behavior
 
-The Stage 4.5 (#55) `.gitignore` carve-out logic SHALL be refactored to call the shared primitive, with byte-equivalent output to the pre-refactor implementation.
+The Stage 4.5 (#55) `.gitignore` carve-out logic SHALL be refactored to call the shared primitive, with **behavior-equivalent** output to the pre-refactor implementation. (Byte-equivalence was found infeasible — the helper uses BEGIN/END sentinels whereas the prior #55 block was a single-marker + rationale-comments format; replicating the old format would couple the generic helper to #55's specifics and defeat the extraction. The criterion is therefore identical `git check-ignore` results + a one-time migration of the old format, NOT byte-identical text — see design.md D4.)
 
-#### Scenario: refactored carve-out is byte-equivalent
+#### Scenario: refactored carve-out is behavior-equivalent
 
-- **WHEN** the refactored Stage 4.5 carve-out runs against the existing #55 test fixtures (root `.gitignore`, `.git/info/exclude`, global `core.excludesfile`, and stacked combinations)
-- **THEN** the resulting `.gitignore` content SHALL be byte-equivalent to the pre-refactor output for every fixture
-- **AND** all existing #55 scenarios (add-exception / skip-commit / abort / nested-gitignore) SHALL continue to pass
+- **WHEN** the refactored Stage 4.5 carve-out runs against a `.gitignore` that excludes `.claude/`
+- **THEN** the run-log path `.claude/.idd/issue-runs/<f>.jsonl` SHALL become trackable (`git check-ignore` reports NOT ignored)
+- **AND** sibling `.claude/<other>` paths SHALL remain ignored
+- **AND** the bare `.claude/` line SHALL be removed
+- **AND** the gate's user-facing options, summary lines, and `JSONL_GITIGNORE_DECISION` values SHALL be unchanged
 
-#### Scenario: refactor does not change #55 observable surface
+#### Scenario: one-time migration of pre-#192 old-format block
 
-- **WHEN** Stage 4.5 dispatches the gate decision after the refactor
-- **THEN** the gate's user-facing options, summary lines, and `JSONL_GITIGNORE_DECISION` values SHALL be unchanged
+- **WHEN** the refactored carve-out runs against a `.gitignore` already containing a pre-#192 OLD-format #55 block (single marker `# IDD multi-finding run log carve-out (idd-issue Stage 4.5, #55)` + rationale comments + the 5 pattern lines, no END sentinel)
+- **THEN** the old block SHALL be stripped and replaced by the new BEGIN/END-sentinel block, with **no duplicate** (the new sentinel appears exactly once)
+- **AND** unrelated user content adjacent to the old block SHALL be preserved
+
+#### Scenario: third-party clone suppresses the Add-carve-out option (#193)
+
+- **WHEN** the Stage 4.5 gate fires in a third-party clone (origin owner ≠ you AND no push permission, per Step 0.5.E detection)
+- **THEN** the gate SHALL NOT offer the "Add carve-out chain to `.gitignore`" option (it would pollute a repo you don't own)
+- **AND** SHALL offer only skip-commit (local-only) / abort, keeping the run log local

--- a/openspec/changes/add-third-party-clone-setup/specs/idd-third-party-clone-detection/spec.md
+++ b/openspec/changes/add-third-party-clone-setup/specs/idd-third-party-clone-detection/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: idd-issue Step 0.5.E third-party clone detection branch
+
+The `idd-issue` skill SHALL add a third branch to Step 0.5.E (fork-aware detection) that fires when the origin repo is neither owned by nor pushable by the authenticated user. The branch SHALL be evaluated AFTER the fork branch (E2) and BEFORE the non-fork-use-origin branch (E1).
+
+#### Scenario: third-party clone detected via hybrid signal
+
+- **WHEN** `idd-issue` runs Step 0.5.E with no existing config, `IS_FORK=false`, the origin owner differs from `gh api user --jq .login`, AND `gh api repos/{owner}/{repo} --jq .permissions.push` returns `false`
+- **THEN** the system SHALL classify the working tree as a third-party clone
+- **AND** SHALL present a 3-option AskUserQuestion (Upstream / your tracking repo / local-only) instead of silently using origin
+
+#### Scenario: own repo skips third-party branch with zero extra API
+
+- **WHEN** the origin owner equals the authenticated user's login
+- **THEN** the system SHALL NOT issue the `repos/{owner}/{repo}` push-permission probe
+- **AND** SHALL fall through to the existing E1 (use origin, write config, no prompt) behavior unchanged
+
+#### Scenario: pushable org repo is not third-party
+
+- **WHEN** the origin owner differs from the authenticated user BUT the push-permission probe returns `true`
+- **THEN** the system SHALL treat the repo as the user's own (collaborator / org write access)
+- **AND** SHALL fall through to E1 behavior, NOT the third-party branch
+
+#### Scenario: fork takes precedence over third-party
+
+- **WHEN** `IS_FORK=true` and an upstream exists
+- **THEN** the system SHALL run the existing E2 fork 3-option flow
+- **AND** SHALL NOT evaluate the third-party branch (no double-prompt), regardless of owner-mismatch or push permission
+
+#### Scenario: push-permission probe failure is fail-safe
+
+- **WHEN** the push-permission probe cannot be resolved (auth scope insufficient, rate limit, or API error) after the owner-mismatch pre-filter has matched
+- **THEN** the system SHALL default to treating the repo as third-party (present the 3-option prompt)
+- **AND** SHALL surface a one-line notice that the probe failed and the conservative default was applied
+
+### Requirement: idd-issue third-party routing options
+
+When a third-party clone is detected, the 3-option routing SHALL write config and ignore rules per the chosen option without creating any GitHub repository.
+
+#### Scenario: user picks own tracking repo
+
+- **WHEN** the user selects "your tracking repo" and supplies an existing `owner/repo` (via `--target` or prompt)
+- **THEN** the system SHALL write `github_repo` = that repo to `.claude/.idd/local.json`
+- **AND** SHALL NOT invoke `gh repo create`
+
+#### Scenario: user picks upstream with visibility warning
+
+- **WHEN** the user selects "Upstream (original author's repo)"
+- **THEN** the system SHALL set `github_repo` = origin
+- **AND** SHALL surface a warning that issues opened there are publicly visible on the original author's tracker
+
+#### Scenario: user picks local-only
+
+- **WHEN** the user selects "local-only"
+- **THEN** the system SHALL NOT create a GitHub issue
+- **AND** SHALL inform the user that GitHub-backed idd-* skills are unavailable until a target is configured
+
+### Requirement: idd-config init third-party parity
+
+The `idd-config init` flow SHALL offer the same third-party detection and 3-option setup as `idd-issue` Step 0.5.E.
+
+#### Scenario: idd-config init in a third-party clone
+
+- **WHEN** `/idd-config init` runs in a third-party clone (owner-mismatch + push=false, not a fork)
+- **THEN** it SHALL present the same 3-option routing
+- **AND** SHALL write config + `.git/info/exclude` rule + `pr_policy: never` per the chosen option
+
+### Requirement: idd-issue Step 0 Bootstrap reflects third-party detection
+
+The Step 0 Bootstrap TaskCreate batch description for target resolution SHALL mention the third-party branch so stage tracking reflects it.
+
+#### Scenario: bootstrap task description names third-party branch
+
+- **WHEN** `idd-issue` runs its Step 0 Bootstrap `detect_target_repo` TaskCreate
+- **THEN** the description SHALL include the third-party branch in its resolution-order summary (fork E2 → third-party → E1)

--- a/openspec/changes/add-third-party-clone-setup/specs/idd-third-party-config-placement/spec.md
+++ b/openspec/changes/add-third-party-clone-setup/specs/idd-third-party-config-placement/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: third-party clone config-placement defaults
+
+When a third-party clone is detected, IDD SHALL place its config locally and ignore it via `.git/info/exclude` (never via the upstream's tracked `.gitignore`), and SHALL default `pr_policy` to `never`.
+
+#### Scenario: config ignored via .git/info/exclude
+
+- **WHEN** IDD writes `.claude/.idd/local.json` in a third-party clone
+- **THEN** the system SHALL add a marker-delimited block to `.git/info/exclude` that ignores `.claude/.idd/` (and legacy `.claude/issue-driven-dev.local.*`)
+- **AND** SHALL NOT modify the repo's tracked `.gitignore`
+- **AND** after the write, `git status` SHALL show no IDD-related untracked files
+
+#### Scenario: pr_policy defaults to never
+
+- **WHEN** IDD writes config for a third-party clone
+- **THEN** the written `.claude/.idd/local.json` SHALL include `"pr_policy": "never"`
+- **AND** the rationale (no push permission → local direct-commit) SHALL be surfaced once to the user
+
+#### Scenario: tracked .gitignore is never touched
+
+- **WHEN** IDD sets up ignore rules in a third-party clone
+- **THEN** the system MUST NOT stage, modify, or commit the upstream repo's tracked `.gitignore`
+
+### Requirement: config-protocol documents the placement matrix
+
+`references/config-protocol.md` mechanism 5 SHALL document the third-party detection clause and the config-placement × ignore-mechanism decision matrix.
+
+#### Scenario: config-protocol mechanism 5 names third-party detection
+
+- **WHEN** a reader consults `config-protocol.md` mechanism 5 (git remote fallback / fork-aware detect)
+- **THEN** it SHALL describe the third-party detection (hybrid owner-mismatch + push-permission), its ordering relative to fork detection, and the placement matrix
+- **AND** SHALL state that third-party config defaults to `.git/info/exclude` + `pr_policy: never`
+
+### Requirement: idd-all Phase 0.5 third-party pr_policy default
+
+The `idd-all` Phase 0.5 mode resolution SHALL apply a `pr_policy: never` default when the working tree is a third-party clone and pr_policy is not explicitly set by config or flag.
+
+#### Scenario: idd-all in third-party clone defaults to direct-commit
+
+- **WHEN** `idd-all` Phase 0.5 resolves mode in a third-party clone with no explicit `pr_policy` and no `--pr`/`--no-pr` flag
+- **THEN** it SHALL resolve to `(direct-commit, attended)` with reason citing third-party detection
+- **AND** SHALL print the resolved-tuple notice line including the third-party reason
+
+#### Scenario: explicit flag still overrides third-party default
+
+- **WHEN** `idd-all` runs in a third-party clone with an explicit `--pr` flag
+- **THEN** the explicit flag SHALL take precedence over the third-party `pr_policy: never` default (per existing override precedence)

--- a/openspec/changes/add-third-party-clone-setup/tasks.md
+++ b/openspec/changes/add-third-party-clone-setup/tasks.md
@@ -4,11 +4,11 @@
 
 ## 1. Shared ignore-block writer primitive
 
-- [ ] 1.1 Write tests for `write_idempotent_ignore_block(target, marker, lines, direction)`: idempotent re-run, stale-block upgrade-in-place, adjacent-content preservation
-- [ ] 1.2 Write tests for direction=exclude → `.git/info/exclude` (`git check-ignore` reports ignored)
-- [ ] 1.3 Write tests for direction=re-include → `.gitignore` parent-dir-excluded carve-out chain
-- [ ] 1.4 Implement the primitive (extract from #55 awk state-machine + 5-line carve-out logic)
-- [ ] 1.5 Place the primitive where both `idd-issue` Stage 4.5 and Step 0.5.E can call it (script under `scripts/` or inline-shared reference)
+- [x] 1.1 Write tests for the primitive: idempotent re-run, stale-block upgrade-in-place, adjacent-content preservation → `scripts/tests/git-ignore-block/test.sh`
+- [x] 1.2 Write tests for direction=exclude → `.git/info/exclude` (`git check-ignore` reports ignored)
+- [x] 1.3 Write tests for direction=re-include → `.gitignore` parent-dir-excluded carve-out chain
+- [x] 1.4 Implement the primitive → `scripts/git-ignore-block.sh` (BEGIN/END-sentinel idempotent block writer; re-include expands the carve-out chain). NOTE: fresh implementation, not a literal extract of #55's awk state-machine — the #55 refactor-onto-this is task 2.
+- [x] 1.5 Placed under `scripts/` so both `idd-issue` Stage 4.5 and Step 0.5.E can call it
 
 ## 2. Refactor #55 Stage 4.5 carve-out onto the primitive
 

--- a/openspec/changes/add-third-party-clone-setup/tasks.md
+++ b/openspec/changes/add-third-party-clone-setup/tasks.md
@@ -12,17 +12,15 @@
 
 ## 2. Refactor #55 Stage 4.5 carve-out onto the primitive
 
-> **DEFERRED this apply pass** (resume item). The new feature does not depend on it —
-> the `git-ignore-block.sh` re-include direction is implemented + tested, but porting
-> #55's existing inline awk state-machine onto it requires a **byte-equivalence**
-> reconciliation: the helper uses BEGIN/END sentinels whereas #55 emits a single-marker
-> block, so a literal refactor either (a) changes the helper to match #55's format, or
-> (b) updates #55's fixtures to the sentinel format. That decision + the full fixture
-> port is a self-contained follow-up, safest done as its own commit/review.
+> **RESOLVED (resume pass)** as Option A — behavior-equivalent refactor + migration.
+> byte-equivalence was confirmed infeasible (helper uses BEGIN/END sentinels vs #55's
+> single-marker+comments format). Acceptance criterion amended byte→behavior-equivalent
+> in spec + design D4. Also fixes #193 (third-party clone suppresses the carve-out option).
 
-- [ ] 2.1 Port existing #55 fixtures (root .gitignore / .git/info/exclude / global / stacked / nested) into byte-equivalence harness
-- [ ] 2.2 Refactor Stage 4.5 carve-out to call the primitive (reconcile BEGIN/END-sentinel vs single-marker format)
-- [ ] 2.3 Assert byte-equivalent output for every fixture; assert gate options / summary / `JSONL_GITIGNORE_DECISION` unchanged
+- [x] 2.1 Behavior-equivalence + migration harness → `scripts/tests/stage45-carveout-migration/test.sh` (13 assertions: fresh carve-out, old-format migration no-duplicate + content-preserved, idempotent)
+- [x] 2.2 Refactor Stage 4.5 add-exception to call `git-ignore-block.sh` (migration awk strips old block → bare-`.claude/` sed → helper re-include); same 5-line carve-out → identical `git check-ignore`
+- [x] 2.3 Assert behavior-equivalent (git check-ignore) + gate options / summary / `JSONL_GITIGNORE_DECISION` unchanged (helper test 22/22 confirms helper untouched)
+- [x] 2.4 (#193) Stage 4.5 gate: drop "Add carve-out to .gitignore" option in third-party clones (Case A-TP, mirrors nested Case B) — run log stays local-only
 
 ## 3. idd-issue Step 0.5.E third-party branch
 

--- a/openspec/changes/add-third-party-clone-setup/tasks.md
+++ b/openspec/changes/add-third-party-clone-setup/tasks.md
@@ -18,11 +18,11 @@
 
 ## 3. idd-issue Step 0.5.E third-party branch
 
-- [ ] 3.1 Write tests: owner-mismatch + push=false → third-party; owner-match → E1 (no probe); owner-mismatch + push=true → E1; fork → E2 (no third-party); probe failure → fail-safe third-party
-- [ ] 3.2 Implement hybrid detection (owner pre-filter → conditional push probe) inside the `IS_FORK=false` branch, ordered after E2
-- [ ] 3.3 Implement 3-option routing (upstream + visibility warning / tracking repo via --target, no auto-create / local-only)
-- [ ] 3.4 On chosen option: write `.claude/.idd/local.json` (github_repo + `pr_policy: never`) + call primitive (direction=exclude, target=`.git/info/exclude`, pattern `.claude/.idd/`)
-- [ ] 3.5 Update Step 0 Bootstrap `detect_target_repo` TaskCreate description (resolution order fork E2 → third-party → E1)
+- [~] 3.1 Detection logic lives as inline skill pseudocode in Step 0.5.E (same as existing E1/E2 — not unit-tested independently). The testable extracted portion (the ignore-block write) is covered by task 1's `git-ignore-block` test suite. A dedicated harness for the detection branch would require extracting detection into a script — reasonable follow-up, not done this pass.
+- [x] 3.2 Implement hybrid detection — refined: `viewerPermission` folded into the existing `gh repo view` call (owner-mismatch pre-filter → permission ∈ {WRITE,MAINTAIN,ADMIN}=own), ordered after E2. Zero extra API round-trip even on mismatch.
+- [x] 3.3 Implement 3-option routing (E-TP: upstream + visibility warning / tracking repo via --target, no auto-create / local-only)
+- [x] 3.4 On chosen option: write `.claude/.idd/local.json` (github_repo + `pr_policy: never`) + call `git-ignore-block.sh` (direction=exclude, target=`.git/info/exclude`, pattern `.claude/.idd/` + legacy)
+- [x] 3.5 Update Step 0 Bootstrap `detect_target_repo` TaskCreate description (resolution order fork E2 → third-party → E1)
 
 ## 4. config-protocol documentation
 

--- a/openspec/changes/add-third-party-clone-setup/tasks.md
+++ b/openspec/changes/add-third-party-clone-setup/tasks.md
@@ -1,0 +1,51 @@
+# Tasks — add-third-party-clone-setup
+
+> TDD enforced (`.spectra.yaml` tdd: true). For each behavioral task: write failing test → implement → green.
+
+## 1. Shared ignore-block writer primitive
+
+- [ ] 1.1 Write tests for `write_idempotent_ignore_block(target, marker, lines, direction)`: idempotent re-run, stale-block upgrade-in-place, adjacent-content preservation
+- [ ] 1.2 Write tests for direction=exclude → `.git/info/exclude` (`git check-ignore` reports ignored)
+- [ ] 1.3 Write tests for direction=re-include → `.gitignore` parent-dir-excluded carve-out chain
+- [ ] 1.4 Implement the primitive (extract from #55 awk state-machine + 5-line carve-out logic)
+- [ ] 1.5 Place the primitive where both `idd-issue` Stage 4.5 and Step 0.5.E can call it (script under `scripts/` or inline-shared reference)
+
+## 2. Refactor #55 Stage 4.5 carve-out onto the primitive
+
+- [ ] 2.1 Port existing #55 fixtures (root .gitignore / .git/info/exclude / global / stacked / nested) into byte-equivalence harness
+- [ ] 2.2 Refactor Stage 4.5 carve-out to call the primitive
+- [ ] 2.3 Assert byte-equivalent output for every fixture; assert gate options / summary / `JSONL_GITIGNORE_DECISION` unchanged
+
+## 3. idd-issue Step 0.5.E third-party branch
+
+- [ ] 3.1 Write tests: owner-mismatch + push=false → third-party; owner-match → E1 (no probe); owner-mismatch + push=true → E1; fork → E2 (no third-party); probe failure → fail-safe third-party
+- [ ] 3.2 Implement hybrid detection (owner pre-filter → conditional push probe) inside the `IS_FORK=false` branch, ordered after E2
+- [ ] 3.3 Implement 3-option routing (upstream + visibility warning / tracking repo via --target, no auto-create / local-only)
+- [ ] 3.4 On chosen option: write `.claude/.idd/local.json` (github_repo + `pr_policy: never`) + call primitive (direction=exclude, target=`.git/info/exclude`, pattern `.claude/.idd/`)
+- [ ] 3.5 Update Step 0 Bootstrap `detect_target_repo` TaskCreate description (resolution order fork E2 → third-party → E1)
+
+## 4. config-protocol documentation
+
+- [ ] 4.1 Add third-party detection clause + ordering to mechanism 5
+- [ ] 4.2 Add config-placement × ignore-mechanism decision matrix (own repo / third-party / monorepo)
+
+## 5. idd-config init parity
+
+- [ ] 5.1 Write test: `/idd-config init` in third-party clone presents 3-option + writes config + exclude + pr_policy never
+- [ ] 5.2 Implement parity (reuse Step 0.5.E detection + routing)
+
+## 6. idd-all Phase 0.5 third-party default
+
+- [ ] 6.1 Write test: third-party clone + no explicit pr_policy/flag → `(direct-commit, attended)` with third-party reason; explicit `--pr` still overrides
+- [ ] 6.2 Implement third-party → `pr_policy: never` default in Phase 0.5 resolution precedence (below explicit flags, beside fork override)
+
+## 7. Backward-compat regression
+
+- [ ] 7.1 E1 (own new repo) silent-write unchanged — existing tests green
+- [ ] 7.2 E2 (fork) 3-option unchanged — existing tests green
+- [ ] 7.3 Existing config present → mechanism 4 short-circuits, no re-detection
+
+## 8. Version + changelog
+
+- [ ] 8.1 Bump `idd-issue` / `idd-config` / `idd-all` plugin version
+- [ ] 8.2 CHANGELOG entry referencing #192

--- a/openspec/changes/add-third-party-clone-setup/tasks.md
+++ b/openspec/changes/add-third-party-clone-setup/tasks.md
@@ -26,8 +26,8 @@
 
 ## 4. config-protocol documentation
 
-- [ ] 4.1 Add third-party detection clause + ordering to mechanism 5
-- [ ] 4.2 Add config-placement × ignore-mechanism decision matrix (own repo / third-party / monorepo)
+- [x] 4.1 Add third-party detection clause + ordering (E2 fork → E-TP → E1) + fail-safe to mechanism 5
+- [x] 4.2 Add config-placement × ignore-mechanism decision matrix (own repo / third-party / monorepo)
 
 ## 5. idd-config init parity
 

--- a/openspec/changes/add-third-party-clone-setup/tasks.md
+++ b/openspec/changes/add-third-party-clone-setup/tasks.md
@@ -12,8 +12,16 @@
 
 ## 2. Refactor #55 Stage 4.5 carve-out onto the primitive
 
+> **DEFERRED this apply pass** (resume item). The new feature does not depend on it —
+> the `git-ignore-block.sh` re-include direction is implemented + tested, but porting
+> #55's existing inline awk state-machine onto it requires a **byte-equivalence**
+> reconciliation: the helper uses BEGIN/END sentinels whereas #55 emits a single-marker
+> block, so a literal refactor either (a) changes the helper to match #55's format, or
+> (b) updates #55's fixtures to the sentinel format. That decision + the full fixture
+> port is a self-contained follow-up, safest done as its own commit/review.
+
 - [ ] 2.1 Port existing #55 fixtures (root .gitignore / .git/info/exclude / global / stacked / nested) into byte-equivalence harness
-- [ ] 2.2 Refactor Stage 4.5 carve-out to call the primitive
+- [ ] 2.2 Refactor Stage 4.5 carve-out to call the primitive (reconcile BEGIN/END-sentinel vs single-marker format)
 - [ ] 2.3 Assert byte-equivalent output for every fixture; assert gate options / summary / `JSONL_GITIGNORE_DECISION` unchanged
 
 ## 3. idd-issue Step 0.5.E third-party branch
@@ -31,21 +39,21 @@
 
 ## 5. idd-config init parity
 
-- [ ] 5.1 Write test: `/idd-config init` in third-party clone presents 3-option + writes config + exclude + pr_policy never
-- [ ] 5.2 Implement parity (reuse Step 0.5.E detection + routing)
+- [~] 5.1 Detection + routing is inline skill pseudocode (mirrors Step 0.5.E); shared write path is the task-1-tested helper. No separate harness this pass (same rationale as 3.1).
+- [x] 5.2 Implement parity — idd-config init gains E-TP branch (fork → third-party → E1) + E-TP write recipe (new-path config + pr_policy never + git-ignore-block.sh); bootstrap task descriptions updated.
 
 ## 6. idd-all Phase 0.5 third-party default
 
-- [ ] 6.1 Write test: third-party clone + no explicit pr_policy/flag → `(direct-commit, attended)` with third-party reason; explicit `--pr` still overrides
-- [ ] 6.2 Implement third-party → `pr_policy: never` default in Phase 0.5 resolution precedence (below explicit flags, beside fork override)
+- [~] 6.1 Resolution is inline skill pseudocode; precedence doc updated (entry 7.5). No separate harness this pass (same rationale as 3.1).
+- [x] 6.2 Implement — Phase 0.5 IS_FORK=false branch gains third-party detection; overrides ONLY the `absent` default → `(direct-commit, attended)`; explicit `--pr`/`--no-pr` (top) and explicit pr_policy always/never still win. Precedence list gains entry 7.5.
 
 ## 7. Backward-compat regression
 
-- [ ] 7.1 E1 (own new repo) silent-write unchanged — existing tests green
-- [ ] 7.2 E2 (fork) 3-option unchanged — existing tests green
-- [ ] 7.3 Existing config present → mechanism 4 short-circuits, no re-detection
+- [x] 7.1 E1 (own new repo) silent-write unchanged — preserved by construction (E1 markdown untouched except ordering prose; new branch only fires on IS_FORK=false AND IS_THIRD_PARTY=true)
+- [x] 7.2 E2 (fork) 3-option unchanged — fork branch evaluated first, logic untouched
+- [x] 7.3 Existing config present → mechanism 4 short-circuits before Step 0.5.E (unchanged); third-party detection only runs in the no-config fallback path
 
 ## 8. Version + changelog
 
-- [ ] 8.1 Bump `idd-issue` / `idd-config` / `idd-all` plugin version
-- [ ] 8.2 CHANGELOG entry referencing #192
+- [~] 8.1 Bump plugin version — DEFERRED to release cut (change not fully complete: task 2 pending). plugin.json stays 2.86.0 for now.
+- [x] 8.2 CHANGELOG `[Unreleased]` entry referencing #192

--- a/plugins/issue-driven-dev/CHANGELOG.md
+++ b/plugins/issue-driven-dev/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Third-party clone setup (#192)** — `idd-issue` Step 0.5.E now detects clones of repos you neither own nor can push to (hybrid: owner-mismatch pre-filter + `viewerPermission` folded into the existing `gh repo view`, ordered fork E2 → third-party E-TP → E1) and offers a 3-option routing (upstream w/ public-visibility warning / your own tracking repo via `--target`, never auto-created / local-only). Third-party config defaults to `pr_policy: never` and is kept out of the upstream via `.git/info/exclude` (never the tracked `.gitignore`). `idd-config init` and `idd-all` Phase 0.5 follow suit; `config-protocol.md` documents the detection + config-placement matrix.
 - **`scripts/git-ignore-block.sh`** — shared idempotent, marker-delimited git ignore-block writer (direction=exclude → `.git/info/exclude`; direction=re-include → `.gitignore` parent-dir carve-out chain) with a fixture test suite. (#192)
 
+### Changed
+
+- **Stage 4.5 (#55) jsonl carve-out refactored onto `git-ignore-block.sh`** — behavior-equivalent (identical `git check-ignore` results) with a one-time migration of the pre-#192 old-format block; block format moves to BEGIN/END sentinels. (#192)
+- **Stage 4.5 gate suppresses the "Add carve-out to `.gitignore`" option in third-party clones** (#193) — the run log stays local-only rather than writing into a repo you don't own.
+
+### Fixed
+
+- `git-ignore-block.sh`: abort instead of delete-to-EOF when a BEGIN sentinel is present without its END; `mktemp` instead of a predictable temp file; valueless-option arg-parse guard. (#192 verify findings)
+
 ## [2.86.0] - 2026-06-20
 
 ### Added

--- a/plugins/issue-driven-dev/CHANGELOG.md
+++ b/plugins/issue-driven-dev/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Third-party clone setup (#192)** — `idd-issue` Step 0.5.E now detects clones of repos you neither own nor can push to (hybrid: owner-mismatch pre-filter + `viewerPermission` folded into the existing `gh repo view`, ordered fork E2 → third-party E-TP → E1) and offers a 3-option routing (upstream w/ public-visibility warning / your own tracking repo via `--target`, never auto-created / local-only). Third-party config defaults to `pr_policy: never` and is kept out of the upstream via `.git/info/exclude` (never the tracked `.gitignore`). `idd-config init` and `idd-all` Phase 0.5 follow suit; `config-protocol.md` documents the detection + config-placement matrix.
+- **`scripts/git-ignore-block.sh`** — shared idempotent, marker-delimited git ignore-block writer (direction=exclude → `.git/info/exclude`; direction=re-include → `.gitignore` parent-dir carve-out chain) with a fixture test suite. (#192)
+
 ## [2.86.0] - 2026-06-20
 
 ### Added

--- a/plugins/issue-driven-dev/CHANGELOG.md
+++ b/plugins/issue-driven-dev/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `git-ignore-block.sh`: abort instead of delete-to-EOF when a BEGIN sentinel is present without its END; `mktemp` instead of a predictable temp file; valueless-option arg-parse guard. (#192 verify findings)
+- **macOS/BSD sed portability** — the origin-parsing `sed` used a lazy quantifier `[^/]+?` that is a hard RE error on BSD/macOS sed, silently breaking IDD target resolution (and the new third-party detection) on macOS first-run. Replaced with a POSIX two-step expression across all 6 call sites (idd-issue, idd-config, idd-all, idd-clarify, config-protocol). (#192 verify)
 
 ## [2.86.0] - 2026-06-20
 

--- a/plugins/issue-driven-dev/references/config-protocol.md
+++ b/plugins/issue-driven-dev/references/config-protocol.md
@@ -228,7 +228,7 @@ Predicates compose with the other mechanisms:
 If no config is found anywhere on the path:
 
 ```bash
-ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
 ```
 
 Then run the **fork-aware + third-party detection** (only `idd-issue` does this; other skills just use origin or prompt). Resolution order (first match wins): **E2 fork → E-TP third-party → E1 own**.

--- a/plugins/issue-driven-dev/references/config-protocol.md
+++ b/plugins/issue-driven-dev/references/config-protocol.md
@@ -231,7 +231,43 @@ If no config is found anywhere on the path:
 ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
 ```
 
-Then run the **fork-aware detection** (only `idd-issue` does this; other skills just use origin or prompt).
+Then run the **fork-aware + third-party detection** (only `idd-issue` does this; other skills just use origin or prompt). Resolution order (first match wins): **E2 fork → E-TP third-party → E1 own**.
+
+#### Third-party clone detection (#192)
+
+A **third-party clone** is a clone of a repo you neither own nor can push to (reference / tutorial / study material — e.g. `git clone` of someone else's public repo). It is `IS_FORK=false` yet not yours, so it would otherwise fall into E1 and silently route issues to the original author's public tracker + write IDD config into their working tree.
+
+Detection is **hybrid** — owner-mismatch as a cheap pre-filter, repo permission as the decisive signal, with the permission folded into the same `gh repo view` call (no extra round-trip):
+
+```bash
+ORIGIN_OWNER="${ORIGIN%%/*}"
+SELF_LOGIN=$(gh api user --jq .login 2>/dev/null)
+# viewerPermission came from `gh repo view "$ORIGIN" --json isFork,parent,viewerPermission`
+IS_THIRD_PARTY=false
+if [ -n "$SELF_LOGIN" ] && [ "$ORIGIN_OWNER" != "$SELF_LOGIN" ]; then
+  case "$VIEWER_PERMISSION" in
+    WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;   # org / collaborator you can push to
+    *)                    IS_THIRD_PARTY=true  ;;    # READ/TRIAGE/NONE/probe-fail → fail-safe
+  esac
+fi
+```
+
+- **fork precedence**: E2 (fork) is evaluated before third-party. A fork is also owner-mismatch + often no-push, but carries its own contributor/customization/divergent semantics — judging it first prevents a double-prompt.
+- **fail-safe**: if the permission probe is unavailable (auth scope / rate limit / API error) after owner-mismatch matched, default to third-party (prompt) rather than silently using origin.
+
+When third-party is detected, `idd-issue` Step 0.5.E presents a 3-option routing (Upstream w/ public-visibility warning / your own tracking repo via `--target`, never auto-created / local-only) and applies the placement defaults below.
+
+#### Config-placement × ignore-mechanism matrix
+
+Where IDD config lives and how it is ignored depends on the situation:
+
+| Situation | config location | ignore mechanism |
+|---|---|---|
+| Your own repo | `.claude/.idd/local.json`, committed or globally ignored | per team convention |
+| **third-party clone** | `.claude/.idd/local.json` (local) | **`.git/info/exclude`** ignores `.claude/.idd/` — per-clone, never committed/pushed, never touches the upstream's tracked `.gitignore` |
+| monorepo / nested | walk-up config placed above the git repo (non-git parent) | same |
+
+For third-party clones the config also defaults to `"pr_policy": "never"` (no push permission → local direct-commit; see `idd-all` Phase 0.5). The ignore rule is written via the shared `scripts/git-ignore-block.sh` primitive (direction=exclude). Editing the upstream's tracked `.gitignore` is forbidden — it would stack a commit on their history (= pollution); `.git/info/exclude` lives inside `.git/` and never leaves the clone.
 
 ### Mechanism 6 (orthogonal): Groups — multi-repo cross-linked issue creation
 

--- a/plugins/issue-driven-dev/scripts/git-ignore-block.sh
+++ b/plugins/issue-driven-dev/scripts/git-ignore-block.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# git-ignore-block.sh — idempotent, marker-delimited git ignore-block writer.
+#
+# Shared primitive for:
+#   - idd-issue Step 0.5.E third-party clone setup (#192) — direction=exclude,
+#     target .git/info/exclude (keep IDD config out of an upstream you don't own)
+#   - idd-issue Stage 4.5 jsonl carve-out (#55) — direction=re-include,
+#     target .gitignore (re-include a run-log path whose parent dir is excluded)
+#
+# See: openspec change add-third-party-clone-setup design.md D4.
+#
+# Usage:
+#   git-ignore-block.sh --target <file> --marker <marker-line> \
+#                       --direction <exclude|re-include> [--] PATH_OR_PATTERN...
+#
+#   direction=exclude    : args written verbatim as ignore patterns.
+#   direction=re-include : each arg is a path; expanded to the parent-dir
+#                          carve-out chain (!a / a/* / !a/b / a/b/* / !a/b/c)
+#                          so the path is trackable even when an ancestor is
+#                          excluded (git "cannot re-include a file if a parent
+#                          directory of that file is excluded" rule).
+#
+# Idempotent: same marker + body → no-op; same marker, different body → replace
+# the block in place; surrounding user content preserved. The block is bracketed
+# by BEGIN/END sentinels derived from the marker, so replacement is exact (no
+# fragile pattern state-machine).
+#
+# Exit: 0 written or no-op, 2 usage error.
+
+set -u
+
+TARGET="" MARKER="" DIRECTION=""
+PATTERNS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)    TARGET="${2:-}"; shift 2 ;;
+    --marker)    MARKER="${2:-}"; shift 2 ;;
+    --direction) DIRECTION="${2:-}"; shift 2 ;;
+    --)          shift; while [ $# -gt 0 ]; do PATTERNS+=("$1"); shift; done ;;
+    -*)          echo "✗ git-ignore-block: unknown option: $1" >&2; exit 2 ;;
+    *)           PATTERNS+=("$1"); shift ;;
+  esac
+done
+
+[ -n "$TARGET" ] || { echo "✗ git-ignore-block: --target required" >&2; exit 2; }
+[ -n "$MARKER" ] || { echo "✗ git-ignore-block: --marker required" >&2; exit 2; }
+[ ${#PATTERNS[@]} -gt 0 ] || { echo "✗ git-ignore-block: at least one pattern/path required" >&2; exit 2; }
+case "$DIRECTION" in
+  exclude|re-include) ;;
+  *) echo "✗ git-ignore-block: --direction must be exclude|re-include (got '${DIRECTION}')" >&2; exit 2 ;;
+esac
+
+# --- Build block body ---------------------------------------------------------
+BODY=()
+if [ "$DIRECTION" = "exclude" ]; then
+  for p in "${PATTERNS[@]}"; do BODY+=("$p"); done
+else
+  # re-include: expand each path into the parent-dir carve-out chain.
+  for path in "${PATTERNS[@]}"; do
+    path="${path#/}"; path="${path%/}"
+    IFS='/' read -ra comps <<< "$path"
+    prefix=""
+    n=${#comps[@]}
+    for ((i=0; i<n; i++)); do
+      if [ -z "$prefix" ]; then prefix="${comps[i]}"; else prefix="$prefix/${comps[i]}"; fi
+      BODY+=("!$prefix")
+      if [ $((i+1)) -lt "$n" ]; then BODY+=("$prefix/*"); fi
+    done
+  done
+fi
+
+BEGIN="# >>> ${MARKER} >>>"
+END="# <<< ${MARKER} <<<"
+
+new_block() {
+  printf '%s\n' "$BEGIN"
+  printf '%s\n' "${BODY[@]}"
+  printf '%s\n' "$END"
+}
+
+mkdir -p "$(dirname "$TARGET")"
+touch "$TARGET"
+
+# --- Idempotent write ---------------------------------------------------------
+if grep -qF "$BEGIN" "$TARGET"; then
+  existing="$(awk -v b="$BEGIN" -v e="$END" '$0==b{f=1} f{print} $0==e{f=0}' "$TARGET")"
+  desired="$(new_block)"
+  if [ "$existing" = "$desired" ]; then
+    exit 0   # same marker + same body → no-op
+  fi
+  # Remove stale block (BEGIN..END inclusive), preserving everything else.
+  awk -v b="$BEGIN" -v e="$END" '
+    $0==b{skip=1}
+    !skip{print}
+    $0==e{skip=0}
+  ' "$TARGET" > "$TARGET.tmp"
+  mv "$TARGET.tmp" "$TARGET"
+fi
+
+# Append fresh block, with a blank-line separator when the file already has
+# content (and does not already end in a blank line).
+if [ -s "$TARGET" ] && [ -n "$(tail -c1 "$TARGET")" ]; then
+  printf '\n' >> "$TARGET"
+elif [ -s "$TARGET" ]; then
+  : # already ends in newline; add one more blank for readability is optional — skip
+fi
+new_block >> "$TARGET"
+exit 0

--- a/plugins/issue-driven-dev/scripts/git-ignore-block.sh
+++ b/plugins/issue-driven-dev/scripts/git-ignore-block.sh
@@ -31,11 +31,12 @@ set -u
 
 TARGET="" MARKER="" DIRECTION=""
 PATTERNS=()
+need_val() { [ "$1" -ge 2 ] || { echo "✗ git-ignore-block: $2 needs a value" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
   case "$1" in
-    --target)    TARGET="${2:-}"; shift 2 ;;
-    --marker)    MARKER="${2:-}"; shift 2 ;;
-    --direction) DIRECTION="${2:-}"; shift 2 ;;
+    --target)    need_val $# --target;    TARGET="$2";    shift 2 ;;
+    --marker)    need_val $# --marker;    MARKER="$2";    shift 2 ;;
+    --direction) need_val $# --direction; DIRECTION="$2"; shift 2 ;;
     --)          shift; while [ $# -gt 0 ]; do PATTERNS+=("$1"); shift; done ;;
     -*)          echo "✗ git-ignore-block: unknown option: $1" >&2; exit 2 ;;
     *)           PATTERNS+=("$1"); shift ;;
@@ -83,18 +84,30 @@ touch "$TARGET"
 
 # --- Idempotent write ---------------------------------------------------------
 if grep -qF "$BEGIN" "$TARGET"; then
+  # Refuse to edit a file with a BEGIN sentinel but no matching END — the stale
+  # removal would otherwise delete from BEGIN to EOF and eat unrelated user
+  # content (violating the "surrounding content preserved" guarantee). The tool
+  # never produces such a file itself; this only fires on external corruption.
+  if ! grep -qF "$END" "$TARGET"; then
+    echo "✗ git-ignore-block: '$TARGET' has the BEGIN sentinel but no END sentinel." >&2
+    echo "  Refusing to edit (would delete to EOF). Fix the block manually, then re-run." >&2
+    exit 2
+  fi
   existing="$(awk -v b="$BEGIN" -v e="$END" '$0==b{f=1} f{print} $0==e{f=0}' "$TARGET")"
   desired="$(new_block)"
   if [ "$existing" = "$desired" ]; then
     exit 0   # same marker + same body → no-op
   fi
   # Remove stale block (BEGIN..END inclusive), preserving everything else.
+  # mktemp (not a predictable "$TARGET.tmp") avoids symlink-clobber / TOCTOU.
+  tmp="$(mktemp "$(dirname "$TARGET")/.idd-ignore-block.XXXXXX")" \
+    || { echo "✗ git-ignore-block: mktemp failed in $(dirname "$TARGET")" >&2; exit 2; }
   awk -v b="$BEGIN" -v e="$END" '
     $0==b{skip=1}
     !skip{print}
     $0==e{skip=0}
-  ' "$TARGET" > "$TARGET.tmp"
-  mv "$TARGET.tmp" "$TARGET"
+  ' "$TARGET" > "$tmp"
+  mv "$tmp" "$TARGET"
 fi
 
 # Append fresh block, with a blank-line separator when the file already has

--- a/plugins/issue-driven-dev/scripts/tests/git-ignore-block/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/git-ignore-block/test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test.sh — fixture-dir tests for git-ignore-block.sh (PsychQuant/issue-driven-development#192)
+#
+# Each test spins up a throwaway git repo in a temp dir, runs the helper against
+# .git/info/exclude or .gitignore, and asserts behavior via `git check-ignore`.
+# Self-contained — no live GitHub / network.
+#
+# Usage: bash test.sh   (exit 0 = all pass, 1 = any fail)
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../../git-ignore-block.sh"
+
+. "$HERE/../../lib/assert-helpers.sh"
+
+new_repo() {
+  local d
+  d="$(mktemp -d)"
+  git -C "$d" init -b main -q
+  git -C "$d" config user.email t@t.t
+  git -C "$d" config user.name t
+  git -C "$d" rev-parse --show-toplevel
+}
+
+TMPDIRS=()
+mk() { local r; r="$(new_repo)"; TMPDIRS+=("$r"); printf '%s' "$r"; }
+cleanup() { for d in "${TMPDIRS[@]:-}"; do [ -n "${d:-}" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+MARKER="IDD test block (#192)"
+BEGINLINE="# >>> ${MARKER} >>>"
+
+# --- Test 1: exclude direction → .git/info/exclude ignores the path ---------
+R="$(mk)"
+bash "$SCRIPT" --target "$R/.git/info/exclude" --marker "$MARKER" --direction exclude ".claude/.idd/"
+assert_exit "exclude exits 0" 0 $?
+require "exclude: .claude/.idd/local.json now ignored" git -C "$R" check-ignore -q .claude/.idd/local.json
+refute  "exclude: unrelated path not ignored"          git -C "$R" check-ignore -q src/main.py
+
+# --- Test 2: idempotent re-run (same marker+body) → one block ---------------
+R="$(mk)"
+bash "$SCRIPT" --target "$R/.git/info/exclude" --marker "$MARKER" --direction exclude ".claude/.idd/"
+bash "$SCRIPT" --target "$R/.git/info/exclude" --marker "$MARKER" --direction exclude ".claude/.idd/"
+CNT=$(grep -cF "$BEGINLINE" "$R/.git/info/exclude")
+assert_eq "idempotent: block begin-sentinel appears once" "1" "$CNT"
+
+# --- Test 3: stale block upgrade-in-place (same marker, different body) ------
+R="$(mk)"
+bash "$SCRIPT" --target "$R/.git/info/exclude" --marker "$MARKER" --direction exclude ".claude/old/"
+bash "$SCRIPT" --target "$R/.git/info/exclude" --marker "$MARKER" --direction exclude ".claude/.idd/"
+MCNT=$(grep -cF "$BEGINLINE" "$R/.git/info/exclude")
+assert_eq "stale: begin-sentinel still once after upgrade" "1" "$MCNT"
+require "stale: new pattern ignored" git -C "$R" check-ignore -q .claude/.idd/x
+refute  "stale: old pattern gone"    git -C "$R" check-ignore -q .claude/old/x
+
+# --- Test 4: adjacent user content preserved --------------------------------
+R="$(mk)"
+printf '# user header\n*.log\n' > "$R/.git/info/exclude"
+bash "$SCRIPT" --target "$R/.git/info/exclude" --marker "$MARKER" --direction exclude ".claude/.idd/"
+assert_grep "preserve: user header kept" "# user header" "$(cat "$R/.git/info/exclude")"
+require "preserve: user *.log still effective" git -C "$R" check-ignore -q debug.log
+require "preserve: new exclude effective"      git -C "$R" check-ignore -q .claude/.idd/y
+
+# --- Test 5: re-include direction → parent-dir-excluded carve-out trackable --
+R="$(mk)"
+printf '.claude/\n' > "$R/.gitignore"
+require "re-include precheck: path ignored before carve-out" git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+bash "$SCRIPT" --target "$R/.gitignore" --marker "$MARKER" --direction re-include ".claude/.idd/issue-runs"
+refute  "re-include: issue-runs now trackable"          git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+require "re-include: sibling .claude/other still ignored" git -C "$R" check-ignore -q .claude/other/y
+
+# --- Test 6: usage errors -----------------------------------------------------
+bash "$SCRIPT" --target /tmp/x --marker m --direction bogus foo 2>/dev/null
+assert_exit "bad direction exits 2" 2 $?
+bash "$SCRIPT" --marker m --direction exclude foo 2>/dev/null
+assert_exit "missing --target exits 2" 2 $?
+
+print_summary "git-ignore-block"

--- a/plugins/issue-driven-dev/scripts/tests/git-ignore-block/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/git-ignore-block/test.sh
@@ -75,5 +75,28 @@ bash "$SCRIPT" --target /tmp/x --marker m --direction bogus foo 2>/dev/null
 assert_exit "bad direction exits 2" 2 $?
 bash "$SCRIPT" --marker m --direction exclude foo 2>/dev/null
 assert_exit "missing --target exits 2" 2 $?
+bash "$SCRIPT" --target /tmp/x --direction exclude 2>/dev/null
+assert_exit "missing pattern exits 2" 2 $?
+bash "$SCRIPT" --target 2>/dev/null   # valueless option must not hang/loop
+assert_exit "valueless --target exits 2 (no infinite loop)" 2 $?
+
+# --- Test 7: missing-END corruption → abort, surrounding content preserved ----
+R="$(mk)"
+EXC="$R/.git/info/exclude"
+mkdir -p "$(dirname "$EXC")"
+printf '# >>> %s >>>\n.claude/old/\n# user line AFTER a corrupted (END-less) block\nsecrets/\n' "$MARKER" > "$EXC"
+bash "$SCRIPT" --target "$EXC" --marker "$MARKER" --direction exclude ".claude/.idd/" 2>/dev/null
+assert_exit "missing-END corruption → exit 2 (no delete-to-EOF)" 2 $?
+assert_grep "missing-END: trailing user line preserved" "user line AFTER" "$(cat "$EXC")"
+assert_grep "missing-END: secrets/ line preserved" "secrets/" "$(cat "$EXC")"
+
+# --- Test 8: re-include idempotency (run twice → one block) -------------------
+R="$(mk)"
+printf '.claude/\n' > "$R/.gitignore"
+bash "$SCRIPT" --target "$R/.gitignore" --marker "$MARKER" --direction re-include ".claude/.idd/issue-runs"
+bash "$SCRIPT" --target "$R/.gitignore" --marker "$MARKER" --direction re-include ".claude/.idd/issue-runs"
+RCNT=$(grep -cF "$BEGINLINE" "$R/.gitignore")
+assert_eq "re-include idempotent: begin-sentinel once" "1" "$RCNT"
+refute "re-include idempotent: still trackable" git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
 
 print_summary "git-ignore-block"

--- a/plugins/issue-driven-dev/scripts/tests/stage45-carveout-migration/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/stage45-carveout-migration/test.sh
@@ -50,13 +50,17 @@ apply_stage45_carveout() {
     ' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
     mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
   fi
-  # (2) remove bare .claude/
+  # (2) helper writes the carve-out — BEFORE the destructive sed (mirrors skill).
+  #     Returns the helper's exit code so callers can assert the failure path.
   touch "$GITIGNORE_FILE"
-  sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
-  mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
-  # (3) helper writes the carve-out
-  bash "$HELPER" --target "$GITIGNORE_FILE" \
-    --marker "IDD jsonl run-log carve-out (#55)" --direction re-include ".claude/.idd/issue-runs"
+  if bash "$HELPER" --target "$GITIGNORE_FILE" \
+       --marker "IDD jsonl run-log carve-out (#55)" --direction re-include ".claude/.idd/issue-runs"; then
+    # (3) on success, remove bare .claude/
+    sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
+    mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
+    return 0
+  fi
+  return 1   # helper failed → skill falls back to skip-commit, sed skipped
 }
 
 # --- Test 1: fresh .gitignore with .claude/ → carve-out makes run-log trackable
@@ -116,5 +120,16 @@ refute "4-line: run-log trackable"                git -C "$R" check-ignore -q .c
 assert_grep "4-line: user top preserved"          "# user top" "$(cat "$G")"
 assert_grep "4-line: user tail preserved"         "# user tail" "$(cat "$G")"
 require "4-line: node_modules/ still effective"   git -C "$R" check-ignore -q node_modules/x
+
+# --- Test 5: helper FAILURE (corrupted block) → sed skipped, .gitignore not half-edited
+# A .gitignore with a BEGIN sentinel but no END makes the helper abort (exit 2).
+# The skill then falls back to skip-commit; crucially the bare-`.claude/` sed must
+# NOT have run (it's gated behind helper success), so the file is not half-edited.
+R="$(mk)"; G="$R/.gitignore"
+printf '# top\n.claude/\n%s\n!.claude\n.claude/*\n' "$NEW_SENTINEL" > "$G"   # BEGIN, no END
+apply_stage45_carveout "$G"; RC=$?
+assert_exit "helper-fail: apply returns non-zero (skill → skip-commit)" 1 "$RC"
+require "helper-fail: bare .claude/ NOT removed (sed skipped, not half-edited)" grep -qxF ".claude/" "$G"
+assert_grep "helper-fail: user top line preserved" "# top" "$(cat "$G")"
 
 print_summary "stage45-carveout-migration"

--- a/plugins/issue-driven-dev/scripts/tests/stage45-carveout-migration/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/stage45-carveout-migration/test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# test.sh — Stage 4.5 #55 carve-out refactor onto git-ignore-block.sh (#192 task 2).
+#
+# #55's add-exception case was refactored to call the shared helper. This test
+# mirrors the refactored flow (migration awk + bare-.claude sed + helper call)
+# against throwaway repos and asserts:
+#   - behavior-equivalence: issue-runs becomes trackable, sibling .claude/ stays ignored
+#   - one-time migration: a pre-#192 OLD-format #55 block is stripped (no duplicate)
+#   - user content preserved
+#   - idempotent on re-run
+#
+# Usage: bash test.sh   (exit 0 = all pass)
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$HERE/../../git-ignore-block.sh"
+. "$HERE/../../lib/assert-helpers.sh"
+
+new_repo() {
+  local d; d="$(mktemp -d)"
+  git -C "$d" init -b main -q
+  git -C "$d" config user.email t@t.t
+  git -C "$d" config user.name t
+  git -C "$d" rev-parse --show-toplevel
+}
+TMPDIRS=()
+mk() { local r; r="$(new_repo)"; TMPDIRS+=("$r"); printf '%s' "$r"; }
+cleanup() { for d in "${TMPDIRS[@]:-}"; do [ -n "${d:-}" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+NEW_SENTINEL="# >>> IDD jsonl run-log carve-out (#55) >>>"
+OLD_MARKER="# IDD multi-finding run log carve-out (idd-issue Stage 4.5, #55)"
+
+# Mirror the refactored Stage 4.5 add-exception flow (idd-issue SKILL.md).
+apply_stage45_carveout() {
+  local GITIGNORE_FILE="$1"
+  # (1) migration: strip any OLD single-marker #55 block
+  if grep -qxF "$OLD_MARKER" "$GITIGNORE_FILE" 2>/dev/null; then
+    awk -v marker="$OLD_MARKER" '
+      function is_block_pattern(line) {
+        return (line == "!.claude" || line == ".claude/*" \
+             || line == "!.claude/.idd" || line == ".claude/.idd/*" \
+             || line == "!.claude/.idd/issue-runs")
+      }
+      $0 == marker { skip = 1; state = 1; next }
+      skip && state == 1 { if ($0 ~ /^#/) next; if (is_block_pattern($0)) { state = 2; next } skip = 0 }
+      skip && state == 2 { if ($0 == "!.claude/.idd/issue-runs") { skip = 0; next } if (is_block_pattern($0)) next; skip = 0 }
+      { print }
+    ' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
+    mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
+  fi
+  # (2) remove bare .claude/
+  touch "$GITIGNORE_FILE"
+  sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
+  mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
+  # (3) helper writes the carve-out
+  bash "$HELPER" --target "$GITIGNORE_FILE" \
+    --marker "IDD jsonl run-log carve-out (#55)" --direction re-include ".claude/.idd/issue-runs"
+}
+
+# --- Test 1: fresh .gitignore with .claude/ → carve-out makes run-log trackable
+R="$(mk)"; G="$R/.gitignore"
+printf '.claude/\n' > "$G"
+require "fresh precheck: run-log ignored before" git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+apply_stage45_carveout "$G"
+refute  "fresh: run-log now trackable"           git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+require "fresh: sibling .claude/other still ignored" git -C "$R" check-ignore -q .claude/other/y
+refute  "fresh: bare .claude/ line removed"      grep -qxF ".claude/" "$G"
+
+# --- Test 2: MIGRATION — pre-#192 OLD-format block stripped, no duplicate ------
+R="$(mk)"; G="$R/.gitignore"
+{
+  printf '# user top\n*.log\n.claude/\n'
+  printf '%s\n' "$OLD_MARKER"
+  printf '# rationale comment a\n# rationale comment b\n'
+  printf '!.claude\n.claude/*\n!.claude/.idd\n.claude/.idd/*\n!.claude/.idd/issue-runs\n'
+  printf '\n# user section AFTER block\nbuild/\n'
+} > "$G"
+apply_stage45_carveout "$G"
+refute "migration: OLD marker gone"               grep -qxF "$OLD_MARKER" "$G"
+assert_eq "migration: NEW sentinel appears once" "1" "$(grep -cF "$NEW_SENTINEL" "$G")"
+refute "migration: run-log trackable"             git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+assert_grep "migration: user top preserved"       "# user top" "$(cat "$G")"
+assert_grep "migration: user AFTER section preserved" "# user section AFTER block" "$(cat "$G")"
+require "migration: user *.log still effective"   git -C "$R" check-ignore -q debug.log
+require "migration: user build/ still effective"  git -C "$R" check-ignore -q build/x
+
+# --- Test 3: idempotent — run the refactored flow twice → one block -----------
+R="$(mk)"; G="$R/.gitignore"
+printf '.claude/\n' > "$G"
+apply_stage45_carveout "$G"
+apply_stage45_carveout "$G"
+assert_eq "idempotent: NEW sentinel once after 2 runs" "1" "$(grep -cF "$NEW_SENTINEL" "$G")"
+refute "idempotent: still trackable"              git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+
+print_summary "stage45-carveout-migration"

--- a/plugins/issue-driven-dev/scripts/tests/stage45-carveout-migration/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/stage45-carveout-migration/test.sh
@@ -94,4 +94,27 @@ apply_stage45_carveout "$G"
 assert_eq "idempotent: NEW sentinel once after 2 runs" "1" "$(grep -cF "$NEW_SENTINEL" "$G")"
 refute "idempotent: still trackable"              git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
 
+# --- Test 4: MIGRATION of pre-#192 4-LINE old block (missing leading !.claude) -
+# The historical #55 code had explicit upgrade logic for a 4-line block (marker
+# present but `!.claude` absent). Confirm migration handles it: strip cleanly,
+# no orphan pattern line, no duplicate.
+R="$(mk)"; G="$R/.gitignore"
+{
+  printf '# user top\n.claude/\n'
+  printf '%s\n' "$OLD_MARKER"
+  printf '# rationale\n'
+  printf '.claude/*\n!.claude/.idd\n.claude/.idd/*\n!.claude/.idd/issue-runs\n'
+  printf '\n# user tail\nnode_modules/\n'
+} > "$G"
+apply_stage45_carveout "$G"
+refute "4-line: OLD marker gone"                  grep -qxF "$OLD_MARKER" "$G"
+assert_eq "4-line: NEW sentinel once"            "1" "$(grep -cF "$NEW_SENTINEL" "$G")"
+# no ORPHAN old pattern line left outside the new sentinel block:
+ORPHANS=$(awk -v b="$NEW_SENTINEL" '$0==b{f=1} f{next} /^(!?\.claude(\/(\*|\.idd(\/(\*|issue-runs))?))?)$/{print}' "$G" | wc -l | tr -d ' ')
+assert_eq "4-line: no orphan carve-out pattern outside new block" "0" "$ORPHANS"
+refute "4-line: run-log trackable"                git -C "$R" check-ignore -q .claude/.idd/issue-runs/x.jsonl
+assert_grep "4-line: user top preserved"          "# user top" "$(cat "$G")"
+assert_grep "4-line: user tail preserved"         "# user tail" "$(cat "$G")"
+require "4-line: node_modules/ still effective"   git -C "$R" check-ignore -q node_modules/x
+
 print_summary "stage45-carveout-migration"

--- a/plugins/issue-driven-dev/skills/idd-all/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all/SKILL.md
@@ -217,6 +217,7 @@ gh auth status > /dev/null 2>&1 || abort "gh CLI not authenticated. Run: gh auth
 5. pr_policy: always                              → (PR, unattended)
 6. pr_policy: never                               → (direct-commit, attended)
 7. pr_policy: ask (explicitly set)                → AskUserQuestion (Claude tool)
+7.5 third-party clone + pr_policy absent (#192)   → (direct-commit, attended)  [no push access → local; overrides only the absent default]
 8. pr_policy absent (config 缺 / 整個 config 不存在) → (PR, unattended)  [v2.40.0 backward-compat default]
 ```
 
@@ -256,11 +257,28 @@ else
   if [ "$IS_FORK" = "true" ]; then
     PATH_AXIS="PR"; INTERACTION="unattended"; REASON="fork detected (override pr_policy=$PR_POLICY)"
   else
+    # 3.5 third-party clone detection (#192) — overrides ONLY the `absent` default
+    # (explicit --pr/--no-pr handled above; explicit pr_policy always/never below win).
+    SELF_LOGIN=$(gh api user --jq .login 2>/dev/null)
+    IS_THIRD_PARTY=false
+    if [ -n "$SELF_LOGIN" ] && [ "${GITHUB_REPO%%/*}" != "$SELF_LOGIN" ]; then
+      case "$(gh repo view "$GITHUB_REPO" --json viewerPermission -q .viewerPermission 2>/dev/null)" in
+        WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;
+        *)                    IS_THIRD_PARTY=true  ;;   # READ/TRIAGE/NONE/probe-fail → fail-safe
+      esac
+    fi
+
     # 4-5-7. Config-driven non-ask paths
     case "$PR_POLICY" in
       always) PATH_AXIS="PR";            INTERACTION="unattended"; REASON="pr_policy=always" ;;
       never)  PATH_AXIS="direct-commit"; INTERACTION="attended";   REASON="pr_policy=never" ;;
-      absent) PATH_AXIS="PR";            INTERACTION="unattended"; REASON="pr_policy absent (v2.40.0 default)" ;;
+      absent)
+        if [ "$IS_THIRD_PARTY" = "true" ]; then
+          PATH_AXIS="direct-commit"; INTERACTION="attended"; REASON="third-party clone, no push access (#192)"
+        else
+          PATH_AXIS="PR";            INTERACTION="unattended"; REASON="pr_policy absent (v2.40.0 default)"
+        fi
+        ;;
       ask)
         # 6. Explicit ask — break out of bash flow.
         # AskUserQuestion is a Claude tool, NOT a shell command.

--- a/plugins/issue-driven-dev/skills/idd-all/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all/SKILL.md
@@ -148,7 +148,7 @@ fi
 
 # 3. 從 working tree 推導 GITHUB_REPO + post-derive shape assertion (#8)
 GITHUB_REPO=$(git -C "$CWD" remote get-url origin 2>/dev/null \
-    | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#') \
+    | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#') \
     || abort "Could not determine github_repo from $CWD/.git/config (no 'origin' remote?)"
 
 # Origin URL might be local path / non-typical format; sed could output garbage.

--- a/plugins/issue-driven-dev/skills/idd-clarify/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-clarify/SKILL.md
@@ -131,7 +131,7 @@ done
 # Fallback: derive from origin
 if [ -z "$GITHUB_REPO" ]; then
   GITHUB_REPO=$(git -C "$CWD" remote get-url origin 2>/dev/null \
-    | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+    | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
 fi
 [ -z "$GITHUB_REPO" ] && abort "Could not resolve target repo. Pass --repo owner/repo or set walked-up config."
 ```

--- a/plugins/issue-driven-dev/skills/idd-config/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-config/SKILL.md
@@ -115,7 +115,7 @@ TaskCreate(name="init_show_result", description="show 一次驗收")
 #### Algorithm（與 idd-issue Step 0.5.E 等價）
 
 ```bash
-ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
 
 if [ -z "$ORIGIN" ]; then
   AskUserQuestion(

--- a/plugins/issue-driven-dev/skills/idd-config/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-config/SKILL.md
@@ -106,8 +106,8 @@ Run `/idd-config init` to create one.
 ```
 TaskCreate(name="init_check_existing", description="若 .claude/issue-driven-dev.local.json 已存在 → AskUserQuestion 確認覆蓋")
 TaskCreate(name="init_detect_origin", description="git remote get-url origin → 取 owner/repo")
-TaskCreate(name="init_check_fork", description="gh repo view --json isFork,parent → fork 偵測")
-TaskCreate(name="init_ask_target", description="AskUserQuestion: Upstream / Own fork / Both — fork=true 時強制問")
+TaskCreate(name="init_check_fork", description="gh repo view --json isFork,parent,viewerPermission → fork + third-party 偵測(#192)")
+TaskCreate(name="init_ask_target", description="AskUserQuestion: fork → Upstream/Own fork/Both;third-party → Upstream/tracking repo/local-only(順序 E2 fork → E-TP → E1)")
 TaskCreate(name="init_write_config", description="寫 .claude/issue-driven-dev.local.json")
 TaskCreate(name="init_show_result", description="show 一次驗收")
 ```
@@ -125,15 +125,24 @@ if [ -z "$ORIGIN" ]; then
   # if Enter → prompt for "owner/repo" string
 fi
 
-REPO_JSON=$(gh repo view "$ORIGIN" --json isFork,parent 2>/dev/null)
+REPO_JSON=$(gh repo view "$ORIGIN" --json isFork,parent,viewerPermission 2>/dev/null)
 IS_FORK=$(echo "$REPO_JSON" | jq -r '.isFork')
 UPSTREAM=$(echo "$REPO_JSON" | jq -r '.parent.nameWithOwner // empty')
 
-if [ "$IS_FORK" = "false" ]; then
-  # E1: not a fork → use origin directly
-  TARGET="$ORIGIN"
-  TRACKING_UPSTREAM=""
-elif [ "$IS_FORK" = "true" ] && [ -n "$UPSTREAM" ]; then
+# third-party clone 偵測(hybrid,#192;同 idd-issue Step 0.5.E)
+ORIGIN_OWNER="${ORIGIN%%/*}"
+SELF_LOGIN=$(gh api user --jq .login 2>/dev/null)
+IS_THIRD_PARTY=false
+if [ -n "$SELF_LOGIN" ] && [ "$ORIGIN_OWNER" != "$SELF_LOGIN" ]; then
+  case "$(echo "$REPO_JSON" | jq -r '.viewerPermission // empty')" in
+    WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;
+    *)                    IS_THIRD_PARTY=true  ;;   # fail-safe
+  esac
+fi
+
+# 解析順序(同 Step 0.5.E):E2 fork → E-TP third-party → E1 own
+TRACKING_UPSTREAM=""; PR_POLICY_OUT=""
+if [ "$IS_FORK" = "true" ] && [ -n "$UPSTREAM" ]; then
   # E2: fork → AskUserQuestion three-option
   AskUserQuestion(
     question="$ORIGIN is a fork of $UPSTREAM. Where do new issues go by default?",
@@ -148,6 +157,25 @@ elif [ "$IS_FORK" = "true" ] && [ -n "$UPSTREAM" ]; then
     "Own fork":   TARGET="$ORIGIN";   TRACKING_UPSTREAM="$UPSTREAM"
     "Both":       TARGET="$UPSTREAM"; TRACKING_UPSTREAM="$ORIGIN"
                   # writes a group entry instead — see below
+elif [ "$IS_THIRD_PARTY" = "true" ]; then
+  # E-TP: third-party clone(無 push 權,#192)→ 三選項,預設不污染對方 repo
+  AskUserQuestion(
+    question="$ORIGIN looks like a third-party clone (not yours, no push access). Where do issues go?",
+    options=[
+      "Upstream ($ORIGIN) — ⚠ public, visible to the author",
+      "Your own tracking repo (enter owner/repo) — not auto-created",
+      "Local-only — no GitHub issues"
+    ]
+  )
+  case "$choice":
+    "Upstream":            TARGET="$ORIGIN"
+    "Your tracking repo":  TARGET="<entered owner/repo>"
+    "Local-only":          TARGET=""        # 不寫 github_repo;提示 GitHub-backed idd-* 暫不可用
+  PR_POLICY_OUT="never"                      # 無 push 權 → local direct-commit
+  # third-party 寫法見下方 "third-party 額外寫入"
+else
+  # E1: 你自己的 repo / 你能寫的 org repo → 直接用 origin
+  TARGET="$ORIGIN"
 fi
 
 mkdir -p .claude
@@ -160,6 +188,36 @@ cat > .claude/issue-driven-dev.local.json <<EOF
 }
 EOF
 ```
+
+#### E-TP（third-party clone）額外寫入（#192）
+
+若走 E-TP 分支且選了 target（非 Local-only），**不**用上面的 cat block，改用 third-party 寫法（同 `idd-issue` Step 0.5.E F 段）：
+
+1. config 寫到**新路徑** `.claude/.idd/local.json`，含 `"pr_policy": "never"`：
+
+```bash
+mkdir -p .claude/.idd
+cat > .claude/.idd/local.json <<EOF
+{
+  "github_repo": "$TARGET",
+  "github_owner": "$(echo $TARGET | cut -d/ -f1)",
+  "attachments_release": "attachments",
+  "pr_policy": "never"
+}
+EOF
+```
+
+2. 用共用 helper 把 IDD config 寫進 `.git/info/exclude`（per-clone、不 commit/push、不動對方 `.gitignore`）：
+
+```bash
+"$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
+  --target "$(git rev-parse --git-dir)/info/exclude" \
+  --marker "IDD third-party clone config (#192)" \
+  --direction exclude \
+  ".claude/.idd/" ".claude/issue-driven-dev.local.json" ".claude/issue-driven-dev.local.md"
+```
+
+Local-only（`TARGET=""`）：不寫 `github_repo`，提示 GitHub-backed idd-* 暫不可用。
 
 #### "Both" 模式特殊處理
 

--- a/plugins/issue-driven-dev/skills/idd-config/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-config/SKILL.md
@@ -134,9 +134,12 @@ ORIGIN_OWNER="${ORIGIN%%/*}"
 SELF_LOGIN=$(gh api user --jq .login 2>/dev/null)
 IS_THIRD_PARTY=false
 if [ -n "$SELF_LOGIN" ] && [ "$ORIGIN_OWNER" != "$SELF_LOGIN" ]; then
-  case "$(echo "$REPO_JSON" | jq -r '.viewerPermission // empty')" in
+  VPERM=$(echo "$REPO_JSON" | jq -r '.viewerPermission // empty')
+  case "$VPERM" in
     WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;
-    *)                    IS_THIRD_PARTY=true  ;;   # fail-safe
+    READ|TRIAGE)          IS_THIRD_PARTY=true  ;;
+    *)                    IS_THIRD_PARTY=true        # 空 / NONE / probe 失敗 → fail-safe，且明示提示
+                          echo "ℹ third-party detection: push-permission probe unavailable for $ORIGIN (viewerPermission='$VPERM') — applying conservative third-party default." >&2 ;;
   esac
 fi
 

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -202,7 +202,7 @@ AskUserQuestion 列出每個 candidate 和 group 的 label,讓使用者選
 
 ```bash
 # 1. 拿到 origin 的 owner/repo
-ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
 
 # 2. 一次拿 origin 的 fork 狀態、upstream、以及你對它的權限。
 #    viewerPermission 折進這支 gh repo view → 省掉獨立的 push-permission probe(#192)。
@@ -1472,7 +1472,7 @@ if [ -z "${JSONL_GITIGNORE_DECISION:-}" ]; then
       # as a fresh shell, and on the config-exists path Step 0.5.E never runs at all
       # (walk-up config short-circuits it). The gate must derive third-party-ness
       # itself, exactly as it recomputes IS_NESTED_GITIGNORE above.
-      GATE_ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+      GATE_ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
       GATE_SELF=$(gh api user --jq .login 2>/dev/null)
       IS_THIRD_PARTY=false
       if [ -n "$GATE_SELF" ] && [ -n "$GATE_ORIGIN" ] && [ "${GATE_ORIGIN%%/*}" != "$GATE_SELF" ]; then
@@ -1612,31 +1612,31 @@ case "$JSONL_GITIGNORE_DECISION" in
       mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
     fi
 
-    # (2) Remove any bare `.claude/` / `.claude` line — the carve-out re-includes
-    #     `.claude` via `!.claude`; a lingering bare exclude is redundant. touch
-    #     handles the no-`.gitignore`-yet case (sed errors on a missing file).
-    touch "$GITIGNORE_FILE"
-    sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
-    mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
-
-    # (3) Write the carve-out via the shared helper (idempotent BEGIN/END-sentinel
+    # (2) Write the carve-out via the shared helper (idempotent BEGIN/END-sentinel
     #     block; re-include direction generates the parent-dir carve-out chain).
-    #     CHECK the exit code: the helper aborts (exit 2) on a corrupted block
-    #     (BEGIN sentinel without END). Without this check the branch would fall
-    #     through to "materialize + git add + commit", silently report success, and
-    #     leave the run log uncommitted while `.gitignore` is already half-edited
-    #     (the bare-`.claude/` sed ran). Per verify #192 DA HIGH finding.
-    if ! "$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
-           --target "$GITIGNORE_FILE" \
-           --marker "IDD jsonl run-log carve-out (#55)" \
-           --direction re-include \
-           ".claude/.idd/issue-runs"; then
+    #     Runs BEFORE the destructive bare-`.claude/` sed (#192 DA MEDIUM): the
+    #     helper aborts (exit 2) on a corrupted block (BEGIN without END); on abort
+    #     `.gitignore` must NOT already be half-edited. CHECK the exit code —
+    #     without it the branch falls through to "materialize + git add + commit",
+    #     silently reports success, and leaves the run log uncommitted.
+    touch "$GITIGNORE_FILE"
+    if "$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
+         --target "$GITIGNORE_FILE" \
+         --marker "IDD jsonl run-log carve-out (#55)" \
+         --direction re-include \
+         ".claude/.idd/issue-runs"; then
+      # (3) Helper succeeded → remove any bare `.claude/` / `.claude` line
+      #     (redundant with the `!.claude` re-include). Only after success, so a
+      #     helper abort never leaves `.gitignore` half-edited.
+      sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
+      mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
+      # .gitignore change is committed together with the jsonl materialization below
+    else
       echo "⚠ git-ignore-block helper could not write the carve-out (corrupted block?)." >&2
       echo "  Falling back to skip-commit: run log written locally but NOT committed." >&2
-      echo "  Inspect '$GITIGNORE_FILE' manually, then re-run to retry the carve-out." >&2
+      echo "  .gitignore left untouched by step 3; inspect it, then re-run to retry." >&2
       JSONL_GITIGNORE_DECISION="skip-commit"   # downstream materialize honors this → no git add
     fi
-    # On success: .gitignore change is committed together with the jsonl materialization below
     ;;
   "skip-commit")
     # jsonl will be written but not `git add`ed — dispatch summary shows warning

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -98,7 +98,7 @@ Fork 有兩種相反的使用情境：
 **在動任何事之前**先用 `TaskCreate` 為這個 stage 建 todo list,確保每個 sub-step 都被追蹤:
 
 ```
-TaskCreate(name="detect_target_repo", description="Step 0.5: 解析 target — --target flag → walked-up config → predicate pre-resolve → fork detection")
+TaskCreate(name="detect_target_repo", description="Step 0.5: 解析 target — --target flag → walked-up config → predicate pre-resolve → fork/third-party detection (順序: fork E2 → third-party E-TP → E1)")
 TaskCreate(name="read_source", description="讀取來源(docx → mcp__che-word-mcp 讀文字 + 列圖片)")
 TaskCreate(name="gather_info", description="Step 2: 蒐集 title / type / priority / description")
 TaskCreate(name="reresolve_target", description="Step 2.5: 用 title/labels 重評 content predicates,若新匹配 != tentative_default 則問使用者要不要切")
@@ -204,19 +204,28 @@ AskUserQuestion 列出每個 candidate 和 group 的 label,讓使用者選
 # 1. 拿到 origin 的 owner/repo
 ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
 
-# 2. 查 origin 是不是 fork,以及 upstream 是誰
-REPO_JSON=$(gh repo view "$ORIGIN" --json isFork,parent 2>/dev/null)
+# 2. 一次拿 origin 的 fork 狀態、upstream、以及你對它的權限。
+#    viewerPermission 折進這支 gh repo view → 省掉獨立的 push-permission probe(#192)。
+REPO_JSON=$(gh repo view "$ORIGIN" --json isFork,parent,viewerPermission 2>/dev/null)
 IS_FORK=$(echo "$REPO_JSON" | jq -r '.isFork')
 UPSTREAM=$(echo "$REPO_JSON" | jq -r '.parent.nameWithOwner // empty')
+
+# 3. third-party clone 偵測(hybrid,#192)。owner-mismatch 當 cheap pre-filter;
+#    不符才看權限。viewerPermission ∈ {WRITE,MAINTAIN,ADMIN} = 你能寫 → 視同自己的。
+ORIGIN_OWNER="${ORIGIN%%/*}"
+SELF_LOGIN=$(gh api user --jq .login 2>/dev/null)
+IS_THIRD_PARTY=false
+if [ -n "$SELF_LOGIN" ] && [ "$ORIGIN_OWNER" != "$SELF_LOGIN" ]; then
+  case "$(echo "$REPO_JSON" | jq -r '.viewerPermission // empty')" in
+    WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;   # org / collaborator 可寫
+    *)                    IS_THIRD_PARTY=true  ;;   # READ/TRIAGE/NONE/probe 失敗 → fail-safe 當 third-party
+  esac
+fi
 ```
 
-接下來按既有邏輯:
+**解析順序（決策,first match wins）:E2 fork → E-TP third-party → E1。** fork 也是別人 upstream,但有自己的語意,必須**先判**,否則 third-party 會把 fork 誤吞 → double-prompt。
 
-**E1. `IS_FORK=false`（不是 fork）**
-
-直接用 origin,**寫入 config 到 `$PWD/.claude/issue-driven-dev.local.json`**,繼續。不需要詢問。
-
-**E2. `IS_FORK=true` 且 `UPSTREAM` 存在** → **強制使用 `AskUserQuestion` 呈現三選項**：
+**E2. `IS_FORK=true` 且 `UPSTREAM` 存在**（最先判） → **強制使用 `AskUserQuestion` 呈現三選項**：
 
 | 選項 | target | 適合情境 |
 |------|--------|---------|
@@ -226,9 +235,21 @@ UPSTREAM=$(echo "$REPO_JSON" | jq -r '.parent.nameWithOwner // empty')
 
 「Both」模式：等同於建立一個 ad-hoc group(primary=upstream, tracking=origin)。Step 3 會走 group flow。
 
+**E-TP. `IS_FORK=false` 且 `IS_THIRD_PARTY=true`**（clone 別人的 repo、你無 push 權,#192） → **強制使用 `AskUserQuestion` 呈現三選項**：
+
+| 選項 | target | 寫入 |
+|------|--------|------|
+| **Upstream**（原作者 `$ORIGIN`） | origin | config `github_repo=$ORIGIN`；⚠ **警示:issue 在原作者公開 repo 上人人可見** |
+| **自己的 tracking repo** | 使用者給的 `--target you/repo`（**不自動建**;缺則問） | config `github_repo=<該 repo>` |
+| **Local-only** | — | 不開 GitHub issue;提示 GitHub-backed idd-* 暫不可用 |
+
+選 Upstream 或 tracking repo → 一律走 **F 的 third-party 寫法**（config 加 `pr_policy: never` + `.claude/.idd/` 寫進 `.git/info/exclude`,不污染對方 repo）。
+
+**E1. `IS_FORK=false` 且 `IS_THIRD_PARTY=false`**（你自己的 repo / 你能寫的 org repo） → 直接用 origin,**寫 config（同既有）**,不需要詢問。與既有行為相同。
+
 #### F. 寫回 config(僅在 Step 0.5.E 觸發時)
 
-無論 E1/E2 選了什麼，都把結果寫入 `$PWD/.claude/issue-driven-dev.local.json`：
+無論 E1/E2/E-TP 選了什麼，都把結果寫入 config（E1/E2 用 `$PWD/.claude/issue-driven-dev.local.json`；E-TP 用新路徑 `$PWD/.claude/.idd/local.json`）：
 
 ```json
 {
@@ -240,6 +261,21 @@ UPSTREAM=$(echo "$REPO_JSON" | jq -r '.parent.nameWithOwner // empty')
 ```
 
 `tracking_upstream` 只在 Both 模式或 fork 情境下寫入（讓後續 skill 知道 upstream 是誰）。
+
+**E-TP（third-party clone）額外寫入（#192）**:除上面 config 外,
+
+1. config 加 `"pr_policy": "never"`（你對 origin 無 push 權 → local direct-commit;見 `idd-all` Phase 0.5）。third-party 的 config 放新路徑 `.claude/.idd/local.json`。
+2. 用共用 helper 把 IDD config 寫進 `.git/info/exclude`（per-clone、不 commit/push、**不動對方 tracked `.gitignore`**）:
+
+```bash
+"$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
+  --target "$(git rev-parse --git-dir)/info/exclude" \
+  --marker "IDD third-party clone config (#192)" \
+  --direction exclude \
+  ".claude/.idd/" ".claude/issue-driven-dev.local.json" ".claude/issue-driven-dev.local.md"
+```
+
+   helper 是 idempotent（重跑不重複、stale block 原地替換）。寫完 `git check-ignore .claude/.idd/local.json` 應回報 ignored、`git status` 不該出現任何 IDD 檔。為什麼用 `.git/info/exclude` 不改 `.gitignore`:後者是 tracked 檔,改它＝在對方 history 疊 commit＝污染;前者住 `.git/` 內、永不 push、別人 clone 拿不到。
 
 下次執行時 walked-up config 已存在,走 Step 0.5.B → C 路徑,不再詢問。
 

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -216,9 +216,12 @@ ORIGIN_OWNER="${ORIGIN%%/*}"
 SELF_LOGIN=$(gh api user --jq .login 2>/dev/null)
 IS_THIRD_PARTY=false
 if [ -n "$SELF_LOGIN" ] && [ "$ORIGIN_OWNER" != "$SELF_LOGIN" ]; then
-  case "$(echo "$REPO_JSON" | jq -r '.viewerPermission // empty')" in
-    WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;   # org / collaborator 可寫
-    *)                    IS_THIRD_PARTY=true  ;;   # READ/TRIAGE/NONE/probe 失敗 → fail-safe 當 third-party
+  VPERM=$(echo "$REPO_JSON" | jq -r '.viewerPermission // empty')
+  case "$VPERM" in
+    WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;   # org / collaborator 可寫 → 視同自己的
+    READ|TRIAGE)          IS_THIRD_PARTY=true  ;;   # 明確唯讀 → third-party
+    *)                    IS_THIRD_PARTY=true        # 空 / NONE / probe 失敗 → fail-safe，且明示提示
+                          echo "ℹ third-party detection: push-permission probe unavailable for $ORIGIN (viewerPermission='$VPERM') — applying conservative third-party default." >&2 ;;
   esac
 fi
 ```

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -1490,7 +1490,17 @@ If detection found ignore shadow → enter the AskUserQuestion deliberation mome
 
 > **Why prose**: AskUserQuestion is a Claude Code agent-level tool, not a bash function. Embedding `AskUserQuestion(...)` inside bash was a category error caught in /idd-verify #47 P1 finding 2. Same pattern applies here — agent reads bash detection, branches at agent level on detection result, then handles deliberation as prose.
 
-When detection returns "ignored", agent branches on `$IS_NESTED_GITIGNORE`:
+When detection returns "ignored", agent branches first on whether the working tree is a **third-party clone** (#193), then on `$IS_NESTED_GITIGNORE`:
+
+**Case A-TP — third-party clone** (origin owner ≠ you AND no push permission, per the Step 0.5.E hybrid detection: `viewerPermission ∉ {WRITE,MAINTAIN,ADMIN}`) → **`Add carve-out` option is NOT offered**, regardless of `$IS_NESTED_GITIGNORE`. Writing the carve-out into the upstream's tracked `.gitignore` would pollute a repo you don't own — exactly what #192's third-party setup prevents — and with `pr_policy: never` you are not committing the run log anywhere anyway, so it stays local-only. 2-option prose:
+
+> "Multi-finding dispatch will write run log to `.claude/.idd/issue-runs/<run_id>.jsonl`, but this is a third-party clone (`${SOURCE_FILE}` shadows `.claude/`). The run log stays local-only — IDD will not touch this repo's tracked `.gitignore`. Choose:"
+>
+> Options (default = first):
+> - **`Skip commit (local-only)`** — write jsonl locally but don't `git add` (expected for a clone you don't own).
+> - **`Abort`** — discard in-memory run log + exit before materialization.
+
+If NOT a third-party clone, branch on `$IS_NESTED_GITIGNORE`:
 
 **Case A — `IS_NESTED_GITIGNORE=false`** (source is root `.gitignore`, `.git/info/exclude`, or global `core.excludesfile`) → 3-option prose:
 
@@ -1545,54 +1555,24 @@ case "$JSONL_GITIGNORE_DECISION" in
     # we'll never reach here with a nested source.
     GITIGNORE_FILE=".gitignore"
 
-    REWRITE_BLOCK=$(cat <<'BLOCK'
-# IDD multi-finding run log carve-out (idd-issue Stage 4.5, #55)
-# `.claude/` is excluded by some ignore source (root .gitignore, .git/info/exclude,
-# or global core.excludesfile). The `!.claude` line re-includes the parent
-# directory itself via git's last-matching rule (neutralizes any outer source),
-# then `.claude/*` re-excludes everything inside, and the carve-out re-includes
-# only the run-log path. Other contents of .claude/ remain ignored.
-!.claude
-.claude/*
-!.claude/.idd
-.claude/.idd/*
-!.claude/.idd/issue-runs
-BLOCK
-)
+    # Refactored onto the shared git-ignore-block.sh helper (#192 task 2).
+    # Behavior-equivalent to the prior inline implementation: the helper's
+    # re-include direction expands `.claude/.idd/issue-runs` into the SAME 5-line
+    # carve-out chain (!.claude / .claude/* / !.claude/.idd / .claude/.idd/* /
+    # !.claude/.idd/issue-runs) → identical `git check-ignore` results. The block
+    # is now wrapped in BEGIN/END sentinels; a one-time migration strips any
+    # pre-#192 OLD-format block so re-runs don't duplicate. (byte-equivalence was
+    # provably impossible without coupling the generic helper to #55's exact
+    # marker+comments format — see openspec design.md D4 amendment.)
 
-    # Idempotency + upgrade: detect both presence of marker AND that the block
-    # contains the universal `!.claude` parent re-include line (per /idd-verify
-    # --pr 71 round 5 P1.1). The marker alone is insufficient — older versions
-    # of this skill emitted a 4-line block with the SAME marker but missing
-    # `!.claude`, which still loses to stacked ignore sources. We upgrade in
-    # place: if marker present BUT `!.claude` line absent, drop the old block
-    # entirely (delete lines from marker through the next blank line / EOF)
-    # then re-append the current universal 5-line block.
-    # `grep -c` exits non-zero on no-match while still printing "0", so `|| echo 0`
-    # would emit "0\n0" and break the `-ge 1` integer test. Pipe to `wc -l` instead —
-    # always yields a clean integer (0 if grep finds nothing or file is absent).
-    HAS_MARKER=$(grep -xF "# IDD multi-finding run log carve-out (idd-issue Stage 4.5, #55)" "$GITIGNORE_FILE" 2>/dev/null | wc -l | tr -d ' ')
-    HAS_PARENT_REINCLUDE=$(grep -xF "!.claude" "$GITIGNORE_FILE" 2>/dev/null | wc -l | tr -d ' ')
-    NEEDS_REWRITE=true
-    if [ "$HAS_MARKER" -ge 1 ] && [ "$HAS_PARENT_REINCLUDE" -ge 1 ]; then
-      # Both marker and the universal `!.claude` line already present → block is
-      # already the current universal form, skip rewrite.
-      NEEDS_REWRITE=false
-    elif [ "$HAS_MARKER" -ge 1 ]; then
-      # Stale block detected — drop it before re-appending the universal block.
-      # State machine (per /idd-verify --pr 71 round 6 P1.1):
-      #   STATE 0: outside block — print line
-      #   STATE 1: just saw marker, in "header" — only consume # comments adjacent
-      #            to marker (the rationale comments we emit) UNTIL first
-      #            carve-out pattern line; any non-# / non-pattern line ENDS skip
-      #   STATE 2: saw a carve-out pattern — only consume more known patterns;
-      #            after consuming the FINAL pattern `!.claude/.idd/issue-runs`,
-      #            END skip
-      #
-      # CRITICAL: do NOT consume blank lines or arbitrary # comments past STATE 1.
-      # If user has `\n# User section` immediately after our stale block, the
-      # blank line ends skip — user content preserved (round 6 P1.1 regression).
-      awk -v marker="# IDD multi-finding run log carve-out (idd-issue Stage 4.5, #55)" '
+    # (1) MIGRATION — strip any OLD single-marker #55 block (pre-#192 format:
+    #     marker + rationale comments + the 5 pattern lines, no END sentinel). The
+    #     state machine consumes marker → adjacent # comments → the known pattern
+    #     lines, stopping at the final pattern; it never eats blank lines or
+    #     unrelated comments (round-6 P1.1 user-content-preservation preserved).
+    OLD_MARKER="# IDD multi-finding run log carve-out (idd-issue Stage 4.5, #55)"
+    if grep -qxF "$OLD_MARKER" "$GITIGNORE_FILE" 2>/dev/null; then
+      awk -v marker="$OLD_MARKER" '
         function is_block_pattern(line) {
           return (line == "!.claude" \
                || line == ".claude/*" \
@@ -1602,38 +1582,34 @@ BLOCK
         }
         $0 == marker { skip = 1; state = 1; next }
         skip && state == 1 {
-          if ($0 ~ /^#/) { next }                      # rationale comment — consume
-          if (is_block_pattern($0)) { state = 2; next } # entered patterns
-          skip = 0                                      # anything else ends skip
+          if ($0 ~ /^#/) { next }
+          if (is_block_pattern($0)) { state = 2; next }
+          skip = 0
         }
         skip && state == 2 {
-          if ($0 == "!.claude/.idd/issue-runs") {       # last pattern → consume and END
-            skip = 0
-            next
-          }
-          if (is_block_pattern($0)) { next }            # intermediate pattern — consume
-          skip = 0                                      # anything else ends skip
+          if ($0 == "!.claude/.idd/issue-runs") { skip = 0; next }
+          if (is_block_pattern($0)) { next }
+          skip = 0
         }
         { print }
       ' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
       mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
     fi
-    if [ "$NEEDS_REWRITE" = "true" ]; then
-      # Remove any existing bare `.claude/` or `.claude` line (we're rewriting that
-      # pattern to `.claude/*` which behaves differently per git docs). Use sed -E
-      # for portable BSD/GNU compatibility; rewrite via tempfile to handle the
-      # no-inplace case. Touch first to handle the no-`.gitignore`-yet case
-      # (sed errors on missing file → would abort under `set -e`).
-      touch "$GITIGNORE_FILE"
-      sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
-      mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
-      # Append carve-out at EOF. If file is now empty, emit without leading newline.
-      if [ -s "$GITIGNORE_FILE" ]; then
-        printf '\n%s\n' "$REWRITE_BLOCK" >> "$GITIGNORE_FILE"
-      else
-        printf '%s\n' "$REWRITE_BLOCK" > "$GITIGNORE_FILE"
-      fi
-    fi
+
+    # (2) Remove any bare `.claude/` / `.claude` line — the carve-out re-includes
+    #     `.claude` via `!.claude`; a lingering bare exclude is redundant. touch
+    #     handles the no-`.gitignore`-yet case (sed errors on a missing file).
+    touch "$GITIGNORE_FILE"
+    sed -E '/^\.claude\/?$/d' "$GITIGNORE_FILE" > "$GITIGNORE_FILE.tmp"
+    mv "$GITIGNORE_FILE.tmp" "$GITIGNORE_FILE"
+
+    # (3) Write the carve-out via the shared helper (idempotent BEGIN/END-sentinel
+    #     block; re-include direction generates the parent-dir carve-out chain).
+    "$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
+      --target "$GITIGNORE_FILE" \
+      --marker "IDD jsonl run-log carve-out (#55)" \
+      --direction re-include \
+      ".claude/.idd/issue-runs"
     # .gitignore change is committed together with the jsonl materialization below
     ;;
   "skip-commit")

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -1466,7 +1466,23 @@ if [ -z "${JSONL_GITIGNORE_DECISION:-}" ]; then
         */.gitignore)                IS_NESTED_GITIGNORE=true  ;;  # nested .gitignore (NOT fixable from root)
         *)                           IS_NESTED_GITIGNORE=false ;;  # other repo-local → defensive fixable
       esac
-      # Agent branches at agent level — see AskUserQuestion section below.
+
+      # Third-party clone detection (#193) — RECOMPUTED here. The IS_THIRD_PARTY
+      # from Step 0.5.E does NOT survive into this gate: each fenced bash block runs
+      # as a fresh shell, and on the config-exists path Step 0.5.E never runs at all
+      # (walk-up config short-circuits it). The gate must derive third-party-ness
+      # itself, exactly as it recomputes IS_NESTED_GITIGNORE above.
+      GATE_ORIGIN=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+      GATE_SELF=$(gh api user --jq .login 2>/dev/null)
+      IS_THIRD_PARTY=false
+      if [ -n "$GATE_SELF" ] && [ -n "$GATE_ORIGIN" ] && [ "${GATE_ORIGIN%%/*}" != "$GATE_SELF" ]; then
+        case "$(gh repo view "$GATE_ORIGIN" --json viewerPermission -q .viewerPermission 2>/dev/null)" in
+          WRITE|MAINTAIN|ADMIN) IS_THIRD_PARTY=false ;;
+          *)                    IS_THIRD_PARTY=true  ;;   # READ/TRIAGE/NONE/probe-fail → fail-safe
+        esac
+      fi
+      # Agent branches at agent level (on $IS_THIRD_PARTY then $IS_NESTED_GITIGNORE)
+      # — see AskUserQuestion section below.
       : # JSONL_GITIGNORE_DECISION set by user choice next
     else
       JSONL_GITIGNORE_DECISION="committed"   # not ignored, silent pass
@@ -1492,7 +1508,7 @@ If detection found ignore shadow → enter the AskUserQuestion deliberation mome
 
 When detection returns "ignored", agent branches first on whether the working tree is a **third-party clone** (#193), then on `$IS_NESTED_GITIGNORE`:
 
-**Case A-TP — third-party clone** (origin owner ≠ you AND no push permission, per the Step 0.5.E hybrid detection: `viewerPermission ∉ {WRITE,MAINTAIN,ADMIN}`) → **`Add carve-out` option is NOT offered**, regardless of `$IS_NESTED_GITIGNORE`. Writing the carve-out into the upstream's tracked `.gitignore` would pollute a repo you don't own — exactly what #192's third-party setup prevents — and with `pr_policy: never` you are not committing the run log anywhere anyway, so it stays local-only. 2-option prose:
+**Case A-TP — third-party clone** (`$IS_THIRD_PARTY = true`, computed in the gate detection block above — origin owner ≠ you AND `viewerPermission ∉ {WRITE,MAINTAIN,ADMIN}`; recomputed at the gate because Step 0.5.E's variable does not survive into this shell) → **`Add carve-out` option is NOT offered**, regardless of `$IS_NESTED_GITIGNORE`. Writing the carve-out into the upstream's tracked `.gitignore` would pollute a repo you don't own — exactly what #192's third-party setup prevents — and with `pr_policy: never` you are not committing the run log anywhere anyway, so it stays local-only. 2-option prose:
 
 > "Multi-finding dispatch will write run log to `.claude/.idd/issue-runs/<run_id>.jsonl`, but this is a third-party clone (`${SOURCE_FILE}` shadows `.claude/`). The run log stays local-only — IDD will not touch this repo's tracked `.gitignore`. Choose:"
 >
@@ -1605,12 +1621,22 @@ case "$JSONL_GITIGNORE_DECISION" in
 
     # (3) Write the carve-out via the shared helper (idempotent BEGIN/END-sentinel
     #     block; re-include direction generates the parent-dir carve-out chain).
-    "$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
-      --target "$GITIGNORE_FILE" \
-      --marker "IDD jsonl run-log carve-out (#55)" \
-      --direction re-include \
-      ".claude/.idd/issue-runs"
-    # .gitignore change is committed together with the jsonl materialization below
+    #     CHECK the exit code: the helper aborts (exit 2) on a corrupted block
+    #     (BEGIN sentinel without END). Without this check the branch would fall
+    #     through to "materialize + git add + commit", silently report success, and
+    #     leave the run log uncommitted while `.gitignore` is already half-edited
+    #     (the bare-`.claude/` sed ran). Per verify #192 DA HIGH finding.
+    if ! "$CLAUDE_PLUGIN_ROOT/scripts/git-ignore-block.sh" \
+           --target "$GITIGNORE_FILE" \
+           --marker "IDD jsonl run-log carve-out (#55)" \
+           --direction re-include \
+           ".claude/.idd/issue-runs"; then
+      echo "⚠ git-ignore-block helper could not write the carve-out (corrupted block?)." >&2
+      echo "  Falling back to skip-commit: run log written locally but NOT committed." >&2
+      echo "  Inspect '$GITIGNORE_FILE' manually, then re-run to retry the carve-out." >&2
+      JSONL_GITIGNORE_DECISION="skip-commit"   # downstream materialize honors this → no git add
+    fi
+    # On success: .gitignore change is committed together with the jsonl materialization below
     ;;
   "skip-commit")
     # jsonl will be written but not `git add`ed — dispatch summary shows warning


### PR DESCRIPTION
Refs #192 #193

## Summary

Adds **third-party clone** awareness to IDD target resolution. When you `git clone` a repo you neither own nor can push to (reference / tutorial / study material), IDD now:

- **Detects** it (hybrid: owner-mismatch pre-filter + `viewerPermission`, folded into the existing `gh repo view`; ordered fork E2 → third-party E-TP → E1).
- **Routes** issues via a 3-option prompt (upstream w/ public-visibility warning / your own tracking repo via `--target`, never auto-created / local-only).
- **Keeps IDD config out of the upstream** — writes the ignore rule to `.git/info/exclude` (per-clone, never committed/pushed), never the tracked `.gitignore`; defaults `pr_policy: never`.

Parity across `idd-issue` Step 0.5.E, `idd-config init`, `idd-all` Phase 0.5, and `config-protocol.md`. Extracts a shared `scripts/git-ignore-block.sh` primitive and refactors the Stage 4.5 (#55) carve-out onto it (behavior-equivalent + one-time old-format migration). Also addresses the #193 gap: the Stage 4.5 gate no longer offers a tracked-`.gitignore` carve-out in third-party clones.

## Verification

4-lens Claude ensemble (requirements / logic / security / regression) + **3-round Devil's-Advocate** adversarial re-attack. Cross-model lens (Codex) skipped — auth `token_invalidated`. The DA caught real bugs each round that the PASS lenses missed (variable-out-of-scope at the gate; a BSD/macOS-sed RE error that broke detection on the host platform — also a pre-existing latent bug in 5 other call sites; helper-exit-code silent failure). All fixed; **converged PASS**.

Tests: `git-ignore-block` 22/22 + `stage45-carveout-migration` 23/23. `spectra validate --strict` ✓.

## Checklist
- [x] Diagnose (Complexity: Spectra)
- [x] Spectra discuss → propose → apply (openspec change `add-third-party-clone-setup`)
- [x] Implement (10 commits)
- [x] Verify — converged PASS after 3 DA rounds
- [x] **Verify-gated** — ready to merge → after merge, run `/idd-close` to finalize #192 (manual gate + closing summary; no auto-close trailer)

## Related
- Addresses #193 (third-party Stage 4.5 suppression) — fixed in this branch
- Separate follow-ups (not in this PR): #194 (`--target` allowlist), #195 (E1/E2 config-path migration), #196 (idd-all lazy detection)
- Incidentally repairs a pre-existing macOS/BSD-sed portability bug in IDD target resolution

---
🤖 Generated via the IDD pipeline. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves) — IDD discipline requires manual `/idd-close` after merge.
