### PR TITLE
chore: add .gitattributes line-ending policy — LF global + CRLF fixture exemption + regression lock

### DIFF
--- a/.claude/.idd/attachments/issue-209/_manifest.json
+++ b/.claude/.idd/attachments/issue-209/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 209,
+  "fetched_at": "2026-07-02T12:00:47Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/.claude/.idd/attachments/issue-216/_manifest.json
+++ b/.claude/.idd/attachments/issue-216/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 216,
+  "fetched_at": "2026-07-05T05:47:21Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Line-ending policy (#216): all text files normalize to LF in index and checkout.
+# Prevents whole-file CRLF churn like the diffs caught in #214 R1/R2 verify.
+* text=auto eol=lf
+
+# Deliberate CRLF test fixtures are exempt from text handling entirely (-text).
+# Convention: any future fixture that must keep CRLF bytes adds its own -text line here.
+plugins/issue-driven-dev/scripts/tests/idd-edit/fixtures/19-section-replace-crlf/input.md -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 # Prevents whole-file CRLF churn like the diffs caught in #214 R1/R2 verify.
 * text=auto eol=lf
 
-# Deliberate CRLF test fixtures are exempt from text handling entirely (-text).
+# Deliberate CRLF test fixtures are exempt from text handling via -text (text unset).
+# Note: `git check-attr -a` may still report `eol: lf` from the global rule above —
+# that attribute is inert when `text` is unset; the CRLF bytes are preserved.
 # Convention: any future fixture that must keep CRLF bytes adds its own -text line here.
+# Regression lock: plugins/issue-driven-dev/scripts/tests/git-attributes/test.sh
 plugins/issue-driven-dev/scripts/tests/idd-edit/fixtures/19-section-replace-crlf/input.md -text

--- a/plugins/issue-driven-dev/scripts/tests/git-attributes/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/git-attributes/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# test.sh — regression lock for the repo line-ending policy (#216)
+#
+# Locks the two load-bearing facts of .gitattributes:
+#   1. The deliberate CRLF fixture keeps its CRLF bytes (the -text exemption is
+#      present AND effective). Without this lock, deleting the -text line would
+#      silently degrade fixture 19-section-replace-crlf from a CRLF test into an
+#      LF test with no failing test anywhere (#216 verify, devils-advocate finding).
+#   2. The global `* text=auto eol=lf` policy line exists, so newly added CRLF
+#      text files normalize to LF in the index.
+#
+# Read-only: no index/working-tree mutation (safe to run with staged changes).
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+FIXTURE="plugins/issue-driven-dev/scripts/tests/idd-edit/fixtures/19-section-replace-crlf/input.md"
+PASS=0
+FAIL=0
+
+check() { # <label> <cmd...>
+  local label="$1"; shift
+  if "$@" > /dev/null 2>&1; then
+    echo "  ✓ $label"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label"; FAIL=$((FAIL + 1))
+  fi
+}
+
+cd "$REPO_ROOT" || { echo "✗ cannot cd to repo root"; exit 1; }
+
+# 1a. .gitattributes exists with the global LF policy line
+check "policy: .gitattributes has global '* text=auto eol=lf'" \
+  grep -qE '^\* text=auto eol=lf$' .gitattributes
+
+# 1b. the CRLF fixture has an explicit -text exemption line
+check "policy: fixture has -text exemption line" \
+  grep -qF "$FIXTURE -text" .gitattributes
+
+# 2. attribute resolution: text must be UNSET for the fixture (exemption effective)
+TEXT_ATTR="$(git check-attr text -- "$FIXTURE" | awk -F': ' '{print $NF}')"
+check "check-attr: fixture 'text' resolves to unset (got: $TEXT_ATTR)" \
+  test "$TEXT_ATTR" = "unset"
+
+# 3. index state: fixture is stored with CRLF (i/crlf)
+INDEX_EOL="$(git ls-files --eol -- "$FIXTURE" | awk '{print $1}')"
+check "index: fixture stored as i/crlf (got: $INDEX_EOL)" \
+  test "$INDEX_EOL" = "i/crlf"
+
+# 4. working copy bytes: fixture actually contains CRLF sequences
+check "worktree: fixture bytes contain CRLF" \
+  grep -q $'\r' "$FIXTURE"
+
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Refs #216

## Summary
加 repo line-ending 政策：`.gitattributes` 以 `* text=auto eol=lf` 全域正規化，並以 `-text` 豁免刻意的 CRLF 測試 fixture（`19-section-replace-crlf/input.md`）。renormalize 實測 zero-churn（456 檔已是 LF），故無獨立 renormalize commit（deviation 已在 verify 留痕）。另含 verify-fix：註解精確化 + `tests/git-attributes/test.sh` regression lock（red-green 驗證通過）。

## Verification
6-AI cross-model verification **PASS**（pai-ensemble 2.18.0 canonical：4 lenses + Devil's Advocate + Codex gpt-5.5，0 blocking，8 findings 全 LOW/INFO 已處置）。詳見 issue #216 的 Verify comment。

## Checklist
- [x] Diagnose ✓
- [x] Implement（3 commits）
- [x] Verify ✓（含 2 項 in-scope fix）
- [x] **Verify-gated**: verify PASS — ready to merge → after merge, run /idd-close to finalize this issue (manual gate + closing summary; no auto-close trailer)

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves) — IDD discipline requires manual /idd-close after merge to enforce checklist gate + closing summary.
