### PR TITLE
cluster: gh-egress hardening — mechanical-net precision + unconditional mention net

### DIFF
--- a/.claude/.idd/attachments/issue-117/_manifest.json
+++ b/.claude/.idd/attachments/issue-117/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 117,
+  "fetched_at": "2026-07-05T15:21:43Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/.claude/.idd/attachments/issue-203/_manifest.json
+++ b/.claude/.idd/attachments/issue-203/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 203,
+  "fetched_at": "2026-07-05T15:16:52Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/plugins/issue-driven-dev/rules/privacy-scrubbing.md
+++ b/plugins/issue-driven-dev/rules/privacy-scrubbing.md
@@ -114,16 +114,19 @@ things and **only** these:
    *existence* of the gate deterministic even though its *content* is the LLM's.
    (Q1 resolution: mechanism (a), a required per-call flag — not an env var,
    which could be left globally set and silently satisfy every dispatch.)
-2. **A mechanical last-resort net** catching **only 2 zero-tolerance literal
-   items** — an absolute `/Users/<name>` home path and verbatim `~/.claude.json`
-   content — as belt-and-suspenders if the LLM misses one. It is
-   **level-independent** (fires even at LIGHT: these two are absolute leaks, not
-   "ordinary identifiers"). It performs **no semantic pattern matching**; a
-   semantically-private identifier that is not one of these two literals (e.g. an
-   unpublished project codename) is deliberately **not** caught by the wrapper —
-   that breadth is the LLM self-review's job.
+2. **A mechanical last-resort net** catching **only 3 zero-tolerance mechanical
+   items** — an absolute `/Users/<name>` home path, verbatim `~/.claude.json`
+   content, and an unattested raw `@login` mention token (#117) — as
+   belt-and-suspenders if the LLM misses one. It is **level-independent**
+   (fires even at LIGHT: these are absolute leaks / irreversible notifications,
+   not "ordinary identifiers"). It performs **no semantic pattern matching**; a
+   semantically-private identifier that is not one of these mechanical items
+   (e.g. an unpublished project codename) is deliberately **not** caught by the
+   wrapper — that breadth is the LLM self-review's job.
 
-The wrapper MUST NOT grow a third semantic check; expanding the net requires a
+The wrapper MUST NOT grow a semantic check; the #202 D1/D2 boundary is
+"mechanical token matching only". The 2→3 growth (#117 mention net) stayed on
+the mechanical side of that line; any future semantic expansion requires a
 separate openspec change (spec: "net does not grow into semantic matching").
 
 ## Division of labor vs `sanitize_source_label` (#75)

--- a/plugins/issue-driven-dev/rules/tagging-collaborators.md
+++ b/plugins/issue-driven-dev/rules/tagging-collaborators.md
@@ -95,6 +95,10 @@ User picks from the **actual list**. The "Other" free-text option is fine for ge
 - Use `@login` (not display name, not email)
 - Place mention on its own line or in a clear context (`cc @login` / `@login 想聽你的意見...`)
 - Before `gh issue comment` / `gh issue create` / `gh issue edit`: grep the body for `@\w+` and confirm every match is in the resolved set.
+- **Unconditional scan（v2.92.0+, #117）**：這個 pre-post 掃描**不是** intent-gated — 即使沒有 `--mention` flag、沒有 tagging 意圖，AI-generated body 中**附帶**的 `@xxx` token（內部 codename 如 `@codex`、引用對話原文、動態值如 `@assignee`）一樣會通知同名真實 user。每個 raw token 二擇一：
+  1. **不是 mention** → backtick-escape 成 `` `@xxx` ``（inline code 對 GitHub notification 惰性）或放進 code fence
+  2. **是 mention** → 走完 5-step 協定後，經 `scripts/gh-egress.sh` 派送時帶 `--mention-attested <login1,login2>`（涵蓋**每一個**意圖 mention；部分涵蓋一樣 refuse）
+- **機械 backstop**：`scripts/gh-egress.sh` 的 mention net（#117）會在派送前剝除 fence/inline-code 後掃 `@login` token，未被 `--mention-attested` 涵蓋者 refuse（exit 4）。此網對 email-like `user@host` 不誤觸（prefix guard）。未接線 gh-egress 的 skill 依本 rule 自律（prose 層），機械覆蓋隨 gh-egress rollout 生效。
 
 ```bash
 # Verification step

--- a/plugins/issue-driven-dev/scripts/gh-egress.sh
+++ b/plugins/issue-driven-dev/scripts/gh-egress.sh
@@ -94,12 +94,26 @@ require_scannable_bodyfile() {
 }
 
 ATTESTED=""
+MENTION_ATTESTED=""   # comma-separated logins vetted via rules/tagging-collaborators.md 5-step (#117)
 GH_ARGS=()          # forwarded to gh, byte-identical minus the attestation flag
 SCAN_PARTS=()       # only the drafted prose (--body / --title / --body-file) is scanned
 next_is=""          # "body" | "title" | "bodyfile" when the previous arg expects a value
 while [ $# -gt 0 ]; do
   arg="$1"
   case "$arg" in
+    --mention-attested|--mention-attested=*)
+      # Same malformed-shape guard as --scrub-attested (#203 item 6 / #117).
+      if [ -n "$next_is" ]; then
+        echo "✗ gh-egress: malformed args — '--mention-attested' found where a value for --body/--title/--body-file was expected." >&2
+        exit 2
+      fi
+      case "$arg" in
+        --mention-attested)
+          [ $# -ge 2 ] || { echo "✗ gh-egress: --mention-attested needs a value." >&2; exit 3; }
+          MENTION_ATTESTED="$2"; shift 2; continue ;;
+        *)
+          MENTION_ATTESTED="${arg#--mention-attested=}"; shift; continue ;;
+      esac ;;
     --scrub-attested|--scrub-attested=*)
       # Malformed-shape guard (#203 item 6): the attestation flag appearing where
       # a value for --body/--title/--body-file is still pending means the caller
@@ -194,6 +208,38 @@ if [ -n "$SCAN" ] && [ -r "$CJSON" ]; then
   if [ -n "$KEYS" ] && printf '%s' "$SCAN" | grep -qFf <(printf '%s\n' "$KEYS"); then
     net_refuse "verbatim content copied from ~/.claude.json"
   fi
+fi
+
+# 3. unattested @-mention net (#117). GitHub notifies real users on any raw
+#    @login token in posted prose — irreversibly, and context-blind. AI-generated
+#    bodies routinely carry incidental tokens (internal codenames like @codex,
+#    quoted conversation text, dynamic values), which the intent-gated
+#    tagging-collaborators.md protocol never sees. This net is UNCONDITIONAL:
+#    every raw token must either be escaped (backticks / fenced code — inert on
+#    GitHub, stripped before this scan) or covered by --mention-attested
+#    (set only after the 5-step protocol resolved the logins).
+#    Prefix guard [^[:alnum:]_] keeps email-like user@host out (GitHub does not
+#    notify on those either).
+MSCAN="$(printf '%s' "$SCAN" | awk '/^[[:space:]]*```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g')"
+UNATTESTED_MENTIONS=""
+while IFS= read -r login; do
+  [ -z "$login" ] && continue
+  case ",$MENTION_ATTESTED," in
+    *",$login,"*) : ;;
+    *) UNATTESTED_MENTIONS="$UNATTESTED_MENTIONS @$login" ;;
+  esac
+done < <(printf '%s\n' "$MSCAN" \
+           | grep -oE '(^|[^[:alnum:]_])@[A-Za-z0-9][A-Za-z0-9-]*' \
+           | grep -oE '@[A-Za-z0-9-]+' \
+           | sed 's/^@//' \
+           | sort -u)
+if [ -n "$UNATTESTED_MENTIONS" ]; then
+  echo "✗ gh-egress: REFUSED — unattested @-mention token(s):$UNATTESTED_MENTIONS" >&2
+  echo "  GitHub notifies real users on raw @login tokens (irreversible). Either:" >&2
+  echo "    - escape non-mention tokens in backticks (\`@name\`) — inert on GitHub, or" >&2
+  echo "    - run the rules/tagging-collaborators.md 5-step protocol, then re-dispatch with" >&2
+  echo "      --mention-attested <login1,login2> covering every intended mention." >&2
+  exit 4
 fi
 
 # --- dispatch: byte-for-byte identical to raw `gh issue <verb> ...` -----------

--- a/plugins/issue-driven-dev/scripts/gh-egress.sh
+++ b/plugins/issue-driven-dev/scripts/gh-egress.sh
@@ -24,8 +24,10 @@
 #   (b) A tiny mechanical LAST-RESORT net catching ONLY 2 zero-tolerance LITERAL
 #       items, as belt-and-suspenders for an LLM miss:
 #         1. an absolute macOS home path `/Users/<name>`
-#         2. verbatim `~/.claude.json` content (the path token, or a project-path
-#            string copied out of the user's actual ~/.claude.json)
+#         2. verbatim `~/.claude.json` content (a project-path string copied out
+#            of the user's actual ~/.claude.json `projects` object). The bare
+#            filename token is PUBLIC (Anthropic docs) and deliberately NOT
+#            matched — content is the secret, not the name (#203 item 1).
 #       This net is LEVEL-INDEPENDENT (fires even at LIGHT) because these two are
 #       absolute zero-tolerance leaks, not "ordinary identifiers".
 #
@@ -56,7 +58,8 @@
 #   compat: callers that capture `URL=$(... )` are unaffected).
 #
 # EXIT CODES
-#   0  dispatched (exec gh)          2  usage error (bad/missing verb)
+#   0  dispatched (exec gh)          2  usage error (bad/missing verb / malformed args)
+#   5  unscannable --body-file (not a readable regular file, #203 item 3)
 #   3  attestation missing/invalid   4  mechanical net hit (refused)
 #
 # TEST OVERRIDES (test-only; never set in production)
@@ -78,6 +81,18 @@ case "$VERB" in
 esac
 
 # --- parse: pull out --scrub-attested, forward everything else verbatim -------
+require_scannable_bodyfile() {
+  # Refuse '-' (stdin), FIFOs, process substitutions and anything that is not a
+  # readable REGULAR file (#203 item 3): the gate cannot scan a stream without
+  # consuming the bytes gh needs, and an unreadable file would dispatch unscanned.
+  if [ "$1" = "-" ] || [ ! -f "$1" ] || [ ! -r "$1" ]; then
+    echo "✗ gh-egress: REFUSED — --body-file '$1' is not a readable regular file." >&2
+    echo "  stdin ('-'), FIFOs and process substitutions cannot be scanned without consuming the stream." >&2
+    echo "  Write the body to a regular file first, then re-dispatch." >&2
+    exit 5
+  fi
+}
+
 ATTESTED=""
 GH_ARGS=()          # forwarded to gh, byte-identical minus the attestation flag
 SCAN_PARTS=()       # only the drafted prose (--body / --title / --body-file) is scanned
@@ -85,11 +100,22 @@ next_is=""          # "body" | "title" | "bodyfile" when the previous arg expect
 while [ $# -gt 0 ]; do
   arg="$1"
   case "$arg" in
-    --scrub-attested)
-      [ $# -ge 2 ] || { echo "✗ gh-egress: --scrub-attested needs a value." >&2; exit 3; }
-      ATTESTED="$2"; shift 2; continue ;;
-    --scrub-attested=*)
-      ATTESTED="${arg#--scrub-attested=}"; shift; continue ;;
+    --scrub-attested|--scrub-attested=*)
+      # Malformed-shape guard (#203 item 6): the attestation flag appearing where
+      # a value for --body/--title/--body-file is still pending means the caller
+      # split its tokens (e.g. `--body --scrub-attested warn`) — the drafted
+      # prose would silently escape the scan. Refuse as a usage error.
+      if [ -n "$next_is" ]; then
+        echo "✗ gh-egress: malformed args — '--scrub-attested' found where a value for --body/--title/--body-file was expected (split-token attestation)." >&2
+        exit 2
+      fi
+      case "$arg" in
+        --scrub-attested)
+          [ $# -ge 2 ] || { echo "✗ gh-egress: --scrub-attested needs a value." >&2; exit 3; }
+          ATTESTED="$2"; shift 2; continue ;;
+        *)
+          ATTESTED="${arg#--scrub-attested=}"; shift; continue ;;
+      esac ;;
     -b|--body|-t|--title)
       GH_ARGS+=("$arg")
       case "$arg" in -t|--title) next_is="title" ;; *) next_is="body" ;; esac
@@ -99,12 +125,13 @@ while [ $# -gt 0 ]; do
     -F|--body-file)
       GH_ARGS+=("$arg"); next_is="bodyfile"; shift; continue ;;
     --body-file=*) GH_ARGS+=("$arg"); next_is=""; f="${arg#--body-file=}"
-      [ -r "$f" ] && SCAN_PARTS+=("$(cat "$f")"); shift; continue ;;
+      require_scannable_bodyfile "$f"
+      SCAN_PARTS+=("$(cat "$f")"); shift; continue ;;
     *)
       GH_ARGS+=("$arg")
       case "$next_is" in
         body|title) SCAN_PARTS+=("$arg") ;;
-        bodyfile)   [ -r "$arg" ] && SCAN_PARTS+=("$(cat "$arg")") ;;
+        bodyfile)   require_scannable_bodyfile "$arg"; SCAN_PARTS+=("$(cat "$arg")") ;;
       esac
       next_is=""; shift; continue ;;
   esac
@@ -139,21 +166,31 @@ if printf '%s' "$SCAN" | grep -qE '/Users/[A-Za-z0-9._-]'; then
   net_refuse "an absolute /Users/<name> home path"
 fi
 
-# 2. verbatim ~/.claude.json content.
-#    (i) the literal path/filename token.
-if printf '%s' "$SCAN" | grep -qF '.claude.json'; then
-  net_refuse "a verbatim ~/.claude.json reference"
-fi
-#    (ii) a project-path string copied verbatim out of the user's actual
-#         ~/.claude.json (the "project basename leaks local folder structure"
-#         threat). Extract quoted absolute-path strings (>=2 slashes, >=12 chars)
-#         and match any verbatim in the drafted prose. One grep, no jq dependency.
-CJSON="${IDD_CLAUDE_JSON:-$HOME/.claude.json}"
+# 2. verbatim ~/.claude.json CONTENT. The bare filename/path token used to be
+#    matched here too, but the name is public documentation — only the content
+#    leaks anything. Dropped per #203 item 1 (it also blocked issues discussing
+#    this gate itself, e.g. #202/#203).
+#    A project-path string copied verbatim out of the user's actual
+#    ~/.claude.json `projects` object (the "project basename leaks local folder
+#    structure" threat). When jq is available the extraction is scoped to the
+#    projects object so PUBLIC tool paths (mcpServers[].command etc.) are not
+#    false-flagged (#203 item 2); without jq, fall back to the original
+#    whole-file wide net (fail-closed: over-refusing beats leaking).
+#    ${HOME:-} guard: both IDD_CLAUDE_JSON and HOME unset must not crash under
+#    set -u — the probe just skips (#203 item 4).
+CJSON="${IDD_CLAUDE_JSON:-${HOME:-}/.claude.json}"
 if [ -n "$SCAN" ] && [ -r "$CJSON" ]; then
-  KEYS="$(grep -oE '"(/[^"]{11,})"' "$CJSON" 2>/dev/null \
-            | sed -E 's/^"//; s/"$//' \
-            | grep -E '/[^/]+/' \
-            | sort -u)"
+  if command -v jq >/dev/null 2>&1; then
+    KEYS="$(jq -r '(.projects // {}) | keys[]' "$CJSON" 2>/dev/null \
+              | grep -E '^/.{11,}$' \
+              | grep -E '/[^/]+/' \
+              | sort -u)"
+  else
+    KEYS="$(grep -oE '"(/[^"]{11,})"' "$CJSON" 2>/dev/null \
+              | sed -E 's/^"//; s/"$//' \
+              | grep -E '/[^/]+/' \
+              | sort -u)"
+  fi
   if [ -n "$KEYS" ] && printf '%s' "$SCAN" | grep -qFf <(printf '%s\n' "$KEYS"); then
     net_refuse "verbatim content copied from ~/.claude.json"
   fi
@@ -161,4 +198,6 @@ fi
 
 # --- dispatch: byte-for-byte identical to raw `gh issue <verb> ...` -----------
 GH_BIN="${IDD_GH_BIN:-gh}"
-exec "$GH_BIN" issue "$VERB" "${GH_ARGS[@]:-}"
+# ${arr[@]+...} idiom: empty array expands to NOTHING (":-" would yield one
+# phantom '' positional, #203 item 5); bash-3.2 safe.
+exec "$GH_BIN" issue "$VERB" ${GH_ARGS[@]+"${GH_ARGS[@]}"}

--- a/plugins/issue-driven-dev/scripts/gh-egress.sh
+++ b/plugins/issue-driven-dev/scripts/gh-egress.sh
@@ -245,9 +245,18 @@ MBODY=""
 for p in "${BODY_PARTS[@]:-}"; do MBODY+="$p"$'\n'; done
 # GFM: a fence opener allows at most 3 leading spaces; >=4 is literal indented
 # code and must NOT toggle fence state (logic 117-3 false-negative otherwise).
-MSCAN="$(printf '%s' "$MBODY" | awk '/^ ? ? ?```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g')"
+# URL spans are exempt: GitHub's mention parser does not notify on @handle
+# inside an autolinked URL (unpkg.com/@scope/pkg, mastodon.social/@dev), and
+# backtick-escaping a URL would break the link (DA-117-B, R2).
+MSCAN="$(printf '%s' "$MBODY" | awk '/^ ? ? ?```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g; s|https?://[^[:space:])>]+||g')"
 # Entity-encoded @ (&#64; / &#x40; / &commat;) followed by a login shape: GitHub
 # may decode these before its mention scan — fail closed and refuse outright.
+# Known friction (DA-117-A, accepted): prose that merely DISCUSSES the encoded
+# form also refuses. Unlike the removed .claude.json filename net (public name,
+# zero leak value), a raw entity-encoded @login has essentially one legitimate
+# prose use — discussing bypasses — which is rare and naturally backtick-escapable
+# (this guard runs AFTER fence/inline-code stripping, so `&#64;login` in code
+# spans already passes). Irreversible-notification risk outweighs the friction.
 if printf '%s' "$MSCAN" | grep -qiE '&#0*64;[a-z0-9-]|&#x0*40;[a-z0-9-]|&commat;[a-z0-9-]'; then
   echo "✗ gh-egress: REFUSED — entity-encoded @-mention (e.g. &#64;login) in body." >&2
   echo "  Encoded forms can decode into live mentions on GitHub. Spell it as literal text in backticks instead." >&2

--- a/plugins/issue-driven-dev/scripts/gh-egress.sh
+++ b/plugins/issue-driven-dev/scripts/gh-egress.sh
@@ -141,13 +141,13 @@ while [ $# -gt 0 ]; do
     -F|--body-file)
       GH_ARGS+=("$arg"); next_is="bodyfile"; shift; continue ;;
     -b?*)
-      GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#-b}"); BODY_PARTS+=("${arg#-b}"); shift; continue ;;
+      GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#-b}"); BODY_PARTS+=("${arg#-b}"); next_is=""; shift; continue ;;
     -t?*)
-      GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#-t}"); shift; continue ;;
+      GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#-t}"); next_is=""; shift; continue ;;
     -F?*)
       GH_ARGS+=("$arg"); f="${arg#-F}"
       require_scannable_bodyfile "$f"
-      FCONTENT="$(cat "$f")"; SCAN_PARTS+=("$FCONTENT"); BODY_PARTS+=("$FCONTENT"); shift; continue ;;
+      FCONTENT="$(cat "$f")"; SCAN_PARTS+=("$FCONTENT"); BODY_PARTS+=("$FCONTENT"); next_is=""; shift; continue ;;
     --body-file=*) GH_ARGS+=("$arg"); next_is=""; f="${arg#--body-file=}"
       require_scannable_bodyfile "$f"
       FCONTENT="$(cat "$f")"; SCAN_PARTS+=("$FCONTENT"); BODY_PARTS+=("$FCONTENT"); shift; continue ;;
@@ -247,8 +247,11 @@ for p in "${BODY_PARTS[@]:-}"; do MBODY+="$p"$'\n'; done
 # code and must NOT toggle fence state (logic 117-3 false-negative otherwise).
 # URL spans are exempt: GitHub's mention parser does not notify on @handle
 # inside an autolinked URL (unpkg.com/@scope/pkg, mastodon.social/@dev), and
-# backtick-escaping a URL would break the link (DA-117-B, R2).
-MSCAN="$(printf '%s' "$MBODY" | awk '/^ ? ? ?```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g; s|https?://[^[:space:])>]+||g')"
+# backtick-escaping a URL would break the link (DA-117-B, R2). Only
+# autolink-ELIGIBLE spans qualify — host must contain a dot; no-dot/malformed
+# "URLs" (https://@user, http://localhost/@user) render as literal text where
+# /@name IS a live mention, so they stay in the scan (117-A, R3).
+MSCAN="$(printf '%s' "$MBODY" | awk '/^ ? ? ?```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g; s|https?://[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+[^[:space:])>]*||g')"
 # Entity-encoded @ (&#64; / &#x40; / &commat;) followed by a login shape: GitHub
 # may decode these before its mention scan — fail closed and refuse outright.
 # Known friction (DA-117-A, accepted): prose that merely DISCUSSES the encoded
@@ -257,7 +260,7 @@ MSCAN="$(printf '%s' "$MBODY" | awk '/^ ? ? ?```/{infence=!infence; next} !infen
 # prose use — discussing bypasses — which is rare and naturally backtick-escapable
 # (this guard runs AFTER fence/inline-code stripping, so `&#64;login` in code
 # spans already passes). Irreversible-notification risk outweighs the friction.
-if printf '%s' "$MSCAN" | grep -qiE '&#0*64;[a-z0-9-]|&#x0*40;[a-z0-9-]|&commat;[a-z0-9-]'; then
+if printf '%s' "$MSCAN" | grep -qiE '&#0*64;([a-z0-9-]|&#)|&#x0*40;([a-z0-9-]|&#)|&commat;([a-z0-9-]|&#)'; then
   echo "✗ gh-egress: REFUSED — entity-encoded @-mention (e.g. &#64;login) in body." >&2
   echo "  Encoded forms can decode into live mentions on GitHub. Spell it as literal text in backticks instead." >&2
   exit 4

--- a/plugins/issue-driven-dev/scripts/gh-egress.sh
+++ b/plugins/issue-driven-dev/scripts/gh-egress.sh
@@ -21,7 +21,7 @@
 #       guarantees the step EXISTS; it does not pretend to guarantee the
 #       judgment was correct (that is the LLM's + the ENFORCE block-with-diff's
 #       job — see rules/privacy-scrubbing.md).
-#   (b) A tiny mechanical LAST-RESORT net catching ONLY 2 zero-tolerance LITERAL
+#   (b) A tiny mechanical LAST-RESORT net catching ONLY 3 zero-tolerance MECHANICAL
 #       items, as belt-and-suspenders for an LLM miss:
 #         1. an absolute macOS home path `/Users/<name>`
 #         2. verbatim `~/.claude.json` content (a project-path string copied out
@@ -96,7 +96,9 @@ require_scannable_bodyfile() {
 ATTESTED=""
 MENTION_ATTESTED=""   # comma-separated logins vetted via rules/tagging-collaborators.md 5-step (#117)
 GH_ARGS=()          # forwarded to gh, byte-identical minus the attestation flag
-SCAN_PARTS=()       # only the drafted prose (--body / --title / --body-file) is scanned
+SCAN_PARTS=()       # all drafted prose (--body / --title / --body-file) — privacy nets
+BODY_PARTS=()       # body-channel prose only — mention net (GitHub never notifies on
+                    # title mentions, and a plaintext title cannot be backtick-escaped)
 next_is=""          # "body" | "title" | "bodyfile" when the previous arg expects a value
 while [ $# -gt 0 ]; do
   arg="$1"
@@ -134,18 +136,28 @@ while [ $# -gt 0 ]; do
       GH_ARGS+=("$arg")
       case "$arg" in -t|--title) next_is="title" ;; *) next_is="body" ;; esac
       shift; continue ;;
-    --body=*)   GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#--body=}");   shift; continue ;;
+    --body=*)   GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#--body=}"); BODY_PARTS+=("${arg#--body=}"); shift; continue ;;
     --title=*)  GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#--title=}");  shift; continue ;;
     -F|--body-file)
       GH_ARGS+=("$arg"); next_is="bodyfile"; shift; continue ;;
+    -b?*)
+      GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#-b}"); BODY_PARTS+=("${arg#-b}"); shift; continue ;;
+    -t?*)
+      GH_ARGS+=("$arg"); SCAN_PARTS+=("${arg#-t}"); shift; continue ;;
+    -F?*)
+      GH_ARGS+=("$arg"); f="${arg#-F}"
+      require_scannable_bodyfile "$f"
+      FCONTENT="$(cat "$f")"; SCAN_PARTS+=("$FCONTENT"); BODY_PARTS+=("$FCONTENT"); shift; continue ;;
     --body-file=*) GH_ARGS+=("$arg"); next_is=""; f="${arg#--body-file=}"
       require_scannable_bodyfile "$f"
-      SCAN_PARTS+=("$(cat "$f")"); shift; continue ;;
+      FCONTENT="$(cat "$f")"; SCAN_PARTS+=("$FCONTENT"); BODY_PARTS+=("$FCONTENT"); shift; continue ;;
     *)
       GH_ARGS+=("$arg")
       case "$next_is" in
-        body|title) SCAN_PARTS+=("$arg") ;;
-        bodyfile)   require_scannable_bodyfile "$arg"; SCAN_PARTS+=("$(cat "$arg")") ;;
+        body)       SCAN_PARTS+=("$arg"); BODY_PARTS+=("$arg") ;;
+        title)      SCAN_PARTS+=("$arg") ;;
+        bodyfile)   require_scannable_bodyfile "$arg"; FCONTENT="$(cat "$arg")"
+                    SCAN_PARTS+=("$FCONTENT"); BODY_PARTS+=("$FCONTENT") ;;
       esac
       next_is=""; shift; continue ;;
   esac
@@ -162,7 +174,9 @@ case "$ATTESTED" in
       exit 3 ;;
 esac
 
-# --- (b) mechanical last-resort net (2 zero-tolerance literal items) ----------
+# --- (b) mechanical last-resort net (3 zero-tolerance mechanical items) -------
+# (grown 2→3 by #117 mention net — mechanical token matching, NOT semantic;
+#  the "no semantic matching" boundary from #202 D1/D2 is unchanged)
 # Joined once; the net only ever inspects the drafted prose, never --repo /
 # --label / --milestone etc. (so metadata-only edits are never false-flagged).
 SCAN=""
@@ -194,12 +208,19 @@ fi
 #    set -u — the probe just skips (#203 item 4).
 CJSON="${IDD_CLAUDE_JSON:-${HOME:-}/.claude.json}"
 if [ -n "$SCAN" ] && [ -r "$CJSON" ]; then
+  JQ_OK=0
   if command -v jq >/dev/null 2>&1; then
-    KEYS="$(jq -r '(.projects // {}) | keys[]' "$CJSON" 2>/dev/null \
-              | grep -E '^/.{11,}$' \
-              | grep -E '/[^/]+/' \
-              | sort -u)"
-  else
+    if KEYS_RAW="$(jq -r '(.projects // {}) | keys[]' "$CJSON" 2>/dev/null)"; then
+      JQ_OK=1
+      KEYS="$(printf '%s\n' "$KEYS_RAW" \
+                | grep -E '^/.{11,}$' \
+                | grep -E '/[^/]+/' \
+                | sort -u)"
+    fi
+  fi
+  if [ "$JQ_OK" -eq 0 ]; then
+    # jq absent OR jq parse failure (malformed config) — fail CLOSED to the
+    # whole-file wide net; a silently disabled net would leak (#203 verify sec-2).
     KEYS="$(grep -oE '"(/[^"]{11,})"' "$CJSON" 2>/dev/null \
               | sed -E 's/^"//; s/"$//' \
               | grep -E '/[^/]+/' \
@@ -220,7 +241,18 @@ fi
 #    (set only after the 5-step protocol resolved the logins).
 #    Prefix guard [^[:alnum:]_] keeps email-like user@host out (GitHub does not
 #    notify on those either).
-MSCAN="$(printf '%s' "$SCAN" | awk '/^[[:space:]]*```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g')"
+MBODY=""
+for p in "${BODY_PARTS[@]:-}"; do MBODY+="$p"$'\n'; done
+# GFM: a fence opener allows at most 3 leading spaces; >=4 is literal indented
+# code and must NOT toggle fence state (logic 117-3 false-negative otherwise).
+MSCAN="$(printf '%s' "$MBODY" | awk '/^ ? ? ?```/{infence=!infence; next} !infence{print}' | sed -E 's/`[^`]*`//g')"
+# Entity-encoded @ (&#64; / &#x40; / &commat;) followed by a login shape: GitHub
+# may decode these before its mention scan — fail closed and refuse outright.
+if printf '%s' "$MSCAN" | grep -qiE '&#0*64;[a-z0-9-]|&#x0*40;[a-z0-9-]|&commat;[a-z0-9-]'; then
+  echo "✗ gh-egress: REFUSED — entity-encoded @-mention (e.g. &#64;login) in body." >&2
+  echo "  Encoded forms can decode into live mentions on GitHub. Spell it as literal text in backticks instead." >&2
+  exit 4
+fi
 UNATTESTED_MENTIONS=""
 while IFS= read -r login; do
   [ -z "$login" ] && continue

--- a/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
@@ -150,8 +150,10 @@ assert_exit "projects key still caught after item-2 scoping (exit 4)" 4 $?
 # item 3: non-regular body-file (stdin dash / FIFO / process-sub) → refuse exit 5
 bash "$SCRIPT" create --repo o/r --title T --body-file - "${ATT[@]}" >/dev/null 2>&1
 assert_exit "body-file '-' (stdin) refused — unscannable (#203 item 3, exit 5)" 5 $?
+# No writer process needed: the gate refuses on the not-a-regular-file check
+# WITHOUT opening the FIFO (a background writer would block forever on open()
+# and hold the test's stdout pipe hostage).
 FIFO="$WORK/fifo"; mkfifo "$FIFO"
-( printf 'x' > "$FIFO" & ) 2>/dev/null
 bash "$SCRIPT" create --repo o/r --title T --body-file "$FIFO" "${ATT[@]}" >/dev/null 2>&1
 assert_exit "body-file FIFO refused — unscannable (#203 item 3, exit 5)" 5 $?
 # regular body-file still scanned + dispatched
@@ -179,5 +181,43 @@ assert_eq "zero-arg dispatch has no phantom empty positional (#203 item 5, argv 
 # item 6: --scrub-attested where a --body value is expected → malformed, usage refuse
 bash "$SCRIPT" create --repo o/r --body --scrub-attested warn >/dev/null 2>&1
 assert_exit "split-token attestation refused (#203 item 6, exit 2)" 2 $?
+
+
+# ── #117 unattested @-mention net ────────────────────────────────────────────
+# raw @login token without attestation → refuse (GitHub notification is irreversible)
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "ping @nonexistentuser123 for a second look" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "raw unattested @-mention refused (#117, exit 4)" 4 $?
+
+# backtick-escaped token is inert on GitHub → dispatch
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "the reviewer codename \`@codex\` wrote this" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "backtick-escaped @token NOT caught (#117) → dispatch (exit 0)" 0 $?
+
+# fenced code block containing @token is inert → dispatch
+BODY_FENCED=$'usage example:\n```\ncc @somebody\n```\ndone'
+bash "$SCRIPT" comment 5 --repo o/r --body "$BODY_FENCED" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "fenced @token NOT caught (#117) → dispatch (exit 0)" 0 $?
+
+# email-like user@host must not trip the net (char before @ is alnum)
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "reach me at demo@example.com about this" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "email-like token NOT caught (#117) → dispatch (exit 0)" 0 $?
+
+# attested mention dispatches AND the flag is stripped from forwarded argv
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "cc @kiki830621 please review" "${ATT[@]}" --mention-attested kiki830621 >/dev/null 2>&1
+assert_exit "attested @-mention dispatches (#117, exit 0)" 0 $?
+ARGV="$(tr '\0' '\n' < "$FAKE_GH_ARGV")"
+refute_grep "wrapper strips --mention-attested from gh argv (#117)" "--mention-attested" "$ARGV"
+
+# attestation must cover EVERY token — partial coverage still refuses
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "cc @kiki830621 and also @stranger99" "${ATT[@]}" --mention-attested kiki830621 >/dev/null 2>&1
+assert_exit "partially-attested mentions refused (#117, exit 4)" 4 $?
+
+# split-token guard extends to --mention-attested
+bash "$SCRIPT" create --repo o/r --body --mention-attested kiki830621 "${ATT[@]}" >/dev/null 2>&1
+assert_exit "split-token --mention-attested refused (#117, exit 2)" 2 $?
 
 print_summary "gh-egress"

--- a/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
@@ -281,4 +281,36 @@ bash "$SCRIPT" comment 5 --repo o/r \
   --body "see https://example.com/docs and ping @realperson about it" "${ATT[@]}" >/dev/null 2>&1
 assert_exit "raw mention adjacent to URL still caught (exit 4)" 4 $?
 
+
+# ── R3 fixes (R2-round findings) ─────────────────────────────────────────────
+# 117-A: URL-strip must only exempt autolink-eligible hosts (dot required);
+# no-dot/malformed hosts render as literal text where /@name IS a live mention
+bash "$SCRIPT" comment 5 --repo o/r --body "see https://@realuser now" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "no-host URL @mention still caught (117-A, exit 4)" 4 $?
+bash "$SCRIPT" comment 5 --repo o/r --body "at http://localhost/@realuser today" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "no-dot-host URL @mention still caught (117-A, exit 4)" 4 $?
+# regression: dotted-host URLs stay exempt
+bash "$SCRIPT" comment 5 --repo o/r --body "docs https://unpkg.com/@angular/core here" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "dotted-host URL @handle stays exempt (exit 0)" 0 $?
+
+# 117-B: fully-encoded username (&#64;&#114;ealuser) must also refuse
+bash "$SCRIPT" comment 5 --repo o/r --body "try &#64;&#114;ealuser form" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "double-encoded entity mention refused (117-B, exit 4)" 4 $?
+
+# 117-C: template expansion under zsh — the =-form must reach the wrapper as
+# ONE recognizable arg and dispatch a vetted mention (end-to-end)
+if command -v zsh >/dev/null 2>&1; then
+  MA_OUT="$WORK/zsh-ma-argv"
+  zsh -c '
+    MENTION_ATTESTED="kiki830621"
+    exec bash "$1" comment 5 --repo o/r --body "cc @kiki830621 ok" --scrub-attested warn ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
+  ' zsh "$SCRIPT" >/dev/null 2>&1
+  assert_exit "zsh template =-form expansion dispatches vetted mention (117-C, exit 0)" 0 $?
+fi
+
+# 203-C: attached short-form must reset pending next_is (parser hygiene) —
+# `--body -bX Y` : -bX consumes as attached body, Y must NOT be eaten as body
+bash "$SCRIPT" create --repo o/r --body "-binline body" --title T "${ATT[@]}" >/dev/null 2>&1
+assert_exit "attached form after pending --body keeps parser state sane (exit 0)" 0 $?
+
 print_summary "gh-egress"

--- a/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
@@ -47,7 +47,7 @@ export FAKE_GH_ARGV="$WORK/argv"
 # a non-/Users absolute path so the .claude.json content-overlap net can be
 # proven to fire INDEPENDENTLY of the home-path net.
 export IDD_CLAUDE_JSON="$WORK/fixture-claude.json"
-printf '%s' '{"projects":{"/Users/fixtureuser/secret-lab":{"x":1},"/opt/priv/hidden-proj-xyz":{"y":2}}}' \
+printf '%s' '{"projects":{"/Users/fixtureuser/secret-lab":{"x":1},"/opt/priv/hidden-proj-xyz":{"y":2}},"mcpServers":{"tool":{"command":"/opt/homebrew/bin/uvx-tool"}}}' \
   > "$IDD_CLAUDE_JSON"
 
 ATT=(--scrub-attested warn)
@@ -83,10 +83,11 @@ bash "$SCRIPT" create --repo o/r --title "crash in /Users/bob/tool" \
   --body "clean body" "${ATT[@]}" >/dev/null 2>&1
 assert_exit "literal home path in --title caught (exit 4)" 4 $?
 
-# verbatim ~/.claude.json reference caught
+# bare ~/.claude.json filename mention is PUBLIC info (#203 item 1) — the private
+# thing is its CONTENT (covered by the projects-key net below). Must dispatch.
 bash "$SCRIPT" comment 5 --repo o/r \
   --body "the value comes from ~/.claude.json under projects" "${ATT[@]}" >/dev/null 2>&1
-assert_exit "verbatim .claude.json reference caught (exit 4)" 4 $?
+assert_exit "bare .claude.json filename mention NOT caught (#203 item 1) → dispatch (exit 0)" 0 $?
 
 # verbatim CONTENT copied from ~/.claude.json (non-/Users project key) caught —
 # proves the content-overlap net fires independently of the home-path net
@@ -131,5 +132,52 @@ bash "$SCRIPT" delete 5 "${ATT[@]}" >/dev/null 2>&1
 assert_exit "unknown verb → usage error (exit 2)" 2 $?
 bash "$SCRIPT" >/dev/null 2>&1
 assert_exit "missing verb → usage error (exit 2)" 2 $?
+
+
+# ── #203 mechanical-net precision + edge-case hardening ─────────────────────
+# item 2: public tool path from mcpServers must NOT be treated as a leak
+# (content net scoped to the projects object when jq is available)
+if command -v jq >/dev/null 2>&1; then
+  bash "$SCRIPT" comment 5 --repo o/r \
+    --body "run it via /opt/homebrew/bin/uvx-tool instead" "${ATT[@]}" >/dev/null 2>&1
+  assert_exit "public mcpServers tool path NOT caught (#203 item 2, jq path) → dispatch (exit 0)" 0 $?
+fi
+# item 2 regression: projects key still caught (both jq and fallback paths)
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "reindex blew up on /opt/priv/hidden-proj-xyz again" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "projects key still caught after item-2 scoping (exit 4)" 4 $?
+
+# item 3: non-regular body-file (stdin dash / FIFO / process-sub) → refuse exit 5
+bash "$SCRIPT" create --repo o/r --title T --body-file - "${ATT[@]}" >/dev/null 2>&1
+assert_exit "body-file '-' (stdin) refused — unscannable (#203 item 3, exit 5)" 5 $?
+FIFO="$WORK/fifo"; mkfifo "$FIFO"
+( printf 'x' > "$FIFO" & ) 2>/dev/null
+bash "$SCRIPT" create --repo o/r --title T --body-file "$FIFO" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "body-file FIFO refused — unscannable (#203 item 3, exit 5)" 5 $?
+# regular body-file still scanned + dispatched
+printf 'a clean body from file' > "$WORK/body.txt"
+bash "$SCRIPT" create --repo o/r --title T --body-file "$WORK/body.txt" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "regular body-file still dispatches (exit 0)" 0 $?
+# regular body-file with a leak is still caught (scan path intact)
+printf 'log at /Users/carol/x.log' > "$WORK/leak.txt"
+bash "$SCRIPT" create --repo o/r --title T --body-file "$WORK/leak.txt" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "regular body-file leak still caught (exit 4)" 4 $?
+
+# item 4: HOME + IDD_CLAUDE_JSON both unset → no set -u crash, clean body dispatches
+env -u HOME -u IDD_CLAUDE_JSON IDD_GH_BIN="$STUB" FAKE_GH_ARGV="$FAKE_GH_ARGV" \
+  bash "$SCRIPT" create --repo o/r --title T --body "clean prose" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "HOME+IDD_CLAUDE_JSON unset → no crash, dispatch (#203 item 4, exit 0)" 0 $?
+
+# item 5: zero forwarded args → argv is exactly 2 NUL-terminated fields
+# (issue, create) with NO phantom '' third field. Field count via NUL bytes —
+# command substitution strips trailing newlines so a string compare is blind
+# to the phantom.
+bash "$SCRIPT" create "${ATT[@]}" >/dev/null 2>&1
+NFIELDS="$(tr -cd '\0' < "$FAKE_GH_ARGV" | wc -c | tr -d ' ')"
+assert_eq "zero-arg dispatch has no phantom empty positional (#203 item 5, argv fields)" "2" "$NFIELDS"
+
+# item 6: --scrub-attested where a --body value is expected → malformed, usage refuse
+bash "$SCRIPT" create --repo o/r --body --scrub-attested warn >/dev/null 2>&1
+assert_exit "split-token attestation refused (#203 item 6, exit 2)" 2 $?
 
 print_summary "gh-egress"

--- a/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
@@ -220,4 +220,49 @@ assert_exit "partially-attested mentions refused (#117, exit 4)" 4 $?
 bash "$SCRIPT" create --repo o/r --body --mention-attested kiki830621 "${ATT[@]}" >/dev/null 2>&1
 assert_exit "split-token --mention-attested refused (#117, exit 2)" 2 $?
 
+
+# ── cluster verify in-scope fixes (R1 findings) ──────────────────────────────
+# fix 1 (sec 203-2 / logic LOW): jq PRESENT but ~/.claude.json malformed →
+# content net must fail CLOSED to the grep fallback, not silently disable
+if command -v jq >/dev/null 2>&1; then
+  export IDD_CLAUDE_JSON="$WORK/malformed-claude.json"
+  printf '%s' '{"projects":{"/opt/priv/hidden-mal-xyz":{"x":1},}' > "$IDD_CLAUDE_JSON"   # trailing comma = invalid JSON
+  bash "$SCRIPT" comment 5 --repo o/r \
+    --body "crash traced to /opt/priv/hidden-mal-xyz build" "${ATT[@]}" >/dev/null 2>&1
+  assert_exit "malformed claude.json + jq present → fallback net still catches (fix1, exit 4)" 4 $?
+  export IDD_CLAUDE_JSON="$WORK/fixture-claude.json"
+fi
+
+# fix 2 (sec 117-1): entity-encoded @ forms refused (decode-side notification risk)
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "ping &#64;realuser about this" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "entity-encoded &#64;login refused (fix2, exit 4)" 4 $?
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "or &#x40;realuser even" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "entity-encoded &#x40;login refused (fix2, exit 4)" 4 $?
+
+# fix 3 (logic 117-1): attached short-form values are scanned like their spaced forms
+bash "$SCRIPT" create --repo o/r --title T "-blog at /Users/alice/secret.sh" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "attached -b<body> home-path leak caught (fix3, exit 4)" 4 $?
+bash "$SCRIPT" create --repo o/r --title T "-bcc @sneakymention" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "attached -b<body> raw mention caught (fix3, exit 4)" 4 $?
+printf 'leak at /Users/dave/y.log' > "$WORK/att.txt"
+bash "$SCRIPT" create --repo o/r --title T "-F$WORK/att.txt" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "attached -F<file> content scanned (fix3, exit 4)" 4 $?
+
+# fix 4 (logic 117-2): mention net is BODY-only — title @tokens neither notify nor can be escaped
+bash "$SCRIPT" create --repo o/r --title "responsive @media breakpoints" \
+  --body "clean prose" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "title @token NOT fed to mention net (fix4) → dispatch (exit 0)" 0 $?
+# privacy nets still scan titles (regression guard)
+bash "$SCRIPT" create --repo o/r --title "crash in /Users/eve/tool" \
+  --body "clean" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "title home-path still caught by privacy net (exit 4)" 4 $?
+
+# fix 5 (logic 117-3): 4-space-indented ``` is GFM literal code, NOT a fence —
+# must not toggle fence state and swallow a later real mention
+BODY_IND=$'see:\n    ```\ncc @realafteripseudofence' 
+bash "$SCRIPT" comment 5 --repo o/r --body "$BODY_IND" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "indented pseudo-fence does not hide later mention (fix5, exit 4)" 4 $?
+
 print_summary "gh-egress"

--- a/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/gh-egress/test.sh
@@ -265,4 +265,20 @@ BODY_IND=$'see:\n    ```\ncc @realafteripseudofence'
 bash "$SCRIPT" comment 5 --repo o/r --body "$BODY_IND" "${ATT[@]}" >/dev/null 2>&1
 assert_exit "indented pseudo-fence does not hide later mention (fix5, exit 4)" 4 $?
 
+
+# ── R2 fixes (DA-r2 findings on 4d2e87b) ─────────────────────────────────────
+# DA-117-B: @handle inside a URL never notifies on GitHub — must NOT refuse,
+# and backtick-escaping would break the link
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "docs at https://unpkg.com/@angular/core and https://mastodon.social/@dev profile" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "@handle inside URLs NOT caught (DA-117-B) → dispatch (exit 0)" 0 $?
+# markdown link target with /@handle also exempt
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "see [pkg docs](https://cdn.jsdelivr.net/npm/@scope/pkg) for details" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "markdown link target @handle NOT caught (DA-117-B) → dispatch (exit 0)" 0 $?
+# regression guard: raw mention NEXT TO a URL still caught
+bash "$SCRIPT" comment 5 --repo o/r \
+  --body "see https://example.com/docs and ping @realperson about it" "${ATT[@]}" >/dev/null 2>&1
+assert_exit "raw mention adjacent to URL still caught (exit 4)" 4 $?
+
 print_summary "gh-egress"

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -104,7 +104,7 @@ TaskCreate(name="gather_info", description="Step 2: 蒐集 title / type / priori
 TaskCreate(name="reresolve_target", description="Step 2.5: 用 title/labels 重評 content predicates,若新匹配 != tentative_default 則問使用者要不要切")
 TaskCreate(name="resolve_mentions", description="若有 --mention 或 description 含 @xxx，強制走 rules/tagging-collaborators.md 協定（v2.32.0+）")
 TaskCreate(name="privacy_scrub_gate", description="Step 0.6: 依 repo visibility 解析 $SCRUB_LEVEL (third-party=enforce / own-public=warn / private=light)；每次 egress 前對 drafted body 跑 rules/privacy-scrubbing.md 的 LLM 語意自審，並一律經 scripts/gh-egress.sh --scrub-attested 派送（不直接 gh issue，#202）")
-TaskCreate(name="create_issue", description="Step 3: gh issue create — Single mode / Group mode / Bundle mode(--parent / --blocked-by / --bundle-mode,見 Step 3.B),body 含已驗證的 @login；經 scripts/gh-egress.sh 派送（#202）")
+TaskCreate(name="create_issue", description="Step 3: gh issue create — Single mode / Group mode / Bundle mode(--parent / --blocked-by / --bundle-mode,見 Step 3.B),body 含已驗證的 @login；經 scripts/gh-egress.sh 派送（#202），有 mention 時帶 --mention-attested <resolved-logins>（#117 mention net；未帶會被 refuse）")
 TaskCreate(name="resolve_parent_link", description="Step 3.B: 若 --parent <N> set,驗證 #N 在 target repo + idempotent PATCH parent body task list(見 references/bundle-flags.md § Edit Algorithm)")
 TaskCreate(name="apply_blocked_by", description="Step 3.B: 若 --blocked-by <M>[,...] set,三層 fallback chain — body blockquote(unconditional)+ GraphQL addBlockedByDependency(嘗試)+ parent annotation(若 --parent co-used)")
 TaskCreate(name="orchestrate_bundle_mode", description="Step 3.B: 若 --bundle-mode <ordered|unordered> set,建 epic + N children + 自動套用 --parent + (ordered 時)Blocked-by 鏈;與 group 模式互斥")
@@ -527,7 +527,7 @@ echo "  3) 全部存好後告訴我「ok」，skill 會接手 upload + 嵌入 is
 2. **Type** — bug / feature / refactor / docs
 3. **Priority** — P0（立即）/ P1（本週）/ P2（排程）/ P3（有空再做）
 4. **Description** — 問題描述（bug: 重現步驟 + expected + actual；feature: 需求 + 目的）
-5. **Stakeholders（v2.32.0+，可選）** — 若需要在 issue body 中 tag 人，使用 `--mention <login>[,<login>...]` flag 或自然語言（"tag X"）。**任何 @xxx 必走 [`rules/tagging-collaborators.md`](../../rules/tagging-collaborators.md) 5 步協定**（gh api → fuzzy match → AskUserQuestion fallback → @login 不用 display name → post 前 verify）。違反 = 通知錯人，不可逆。
+5. **Stakeholders（v2.32.0+，可選）** — 若需要在 issue body 中 tag 人，使用 `--mention <login>[,<login>...]` flag 或自然語言（"tag X"）。**任何 @xxx 必走 [`rules/tagging-collaborators.md`](../../rules/tagging-collaborators.md) 5 步協定**（gh api → fuzzy match → AskUserQuestion fallback → @login 不用 display name → post 前 verify）。違反 = 通知錯人，不可逆。派送時把 resolved logins 帶進 `gh-egress.sh --mention-attested <login1,login2>`（#117 unconditional mention net）；非 mention 的附帶 `@xxx` token 一律 backtick-escape。
 
 #### Step 2.0.5: Title sanitization (v2.46.0+, P9 follow-up of #1)
 

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -344,7 +344,7 @@ basename、非公開 collaborator 真名、未發表 context)。**人名由 cont
 
 ```bash
 bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" <create|comment|edit> <原本的 gh args…> \
-  --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
+  --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
 ```
 
 wrapper deterministically enforce「自審跑過」(缺 `--scrub-attested` → refuse,
@@ -620,7 +620,7 @@ if new_match exists AND new_match != tentative_default:
 bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create \
   --repo $GITHUB_REPO \
   --title "$TITLE" \
-  --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"} \
+  --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"} \
   --body "$(cat <<'EOF'
 ## Problem
 
@@ -701,7 +701,7 @@ else
   # Algorithm: append to first contiguous "- [ ]"/"- [x]" section, OR append fresh `## Children` anchor
   NEW_BODY=$(append_to_task_list "$PARENT_BODY" "$ENTRY")
 
-  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$PARENT_NUM" --repo "$GITHUB_REPO" --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
+  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$PARENT_NUM" --repo "$GITHUB_REPO" --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
 fi
 ```
 
@@ -718,7 +718,7 @@ for M in $(echo "$BLOCKED_BY_LIST" | tr ',' '\n'); do
   BLOCKED_BLOCKQUOTE="${BLOCKED_BLOCKQUOTE}> Blocked by #${M}\n"
 done
 NEW_CHILD_BODY="${BLOCKED_BLOCKQUOTE}\n${ORIGINAL_BODY}"
-bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$CHILD_NUM" --repo "$GITHUB_REPO" --body "$NEW_CHILD_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
+bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$CHILD_NUM" --repo "$GITHUB_REPO" --body "$NEW_CHILD_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
 
 # Layer 1:GraphQL native dependency(嘗試,失敗不 abort)
 CHILD_NODE_ID=$(gh issue view "$CHILD_NUM" --repo "$GITHUB_REPO" --json id --jq '.id')
@@ -752,7 +752,7 @@ fi
 EPIC_NUM=$(bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create --repo "$GITHUB_REPO" \
   --title "$EPIC_TITLE" \
   --body "Epic for ${#ITEMS[@]}-item bundle (${BUNDLE_MODE})\n\n## Children\n" \
-  --label "epic" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"} | basename)
+  --label "epic" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"} | basename)
 
 # 2. 建 N children,逐個 auto-apply --parent <epic> + (ordered 時)--blocked-by <prev>
 PREV_CHILD=""
@@ -811,7 +811,7 @@ PRIMARY_URL=$(bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create \
   --repo $PRIMARY_REPO \
   --title "$TITLE" \
   --body "$FULL_BODY" \
-  --label "$TYPE" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"})
+  --label "$TYPE" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"})
 PRIMARY_NUM=$(basename "$PRIMARY_URL")
 
 # 2. 在每個 tracking repo 建追蹤 issue
@@ -831,13 +831,13 @@ ${FULL_BODY}"
     --repo $TRACKING_REPO \
     --title "$TITLE" \
     --body "$TRACKING_BODY" \
-    --label "$TYPE" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"})
+    --label "$TYPE" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"})
   TRACKING_NUM=$(basename "$TRACKING_URL")
   TRACKING_REFS+=("${TRACKING_REPO}#${TRACKING_NUM}")
 done
 
 # 3. 在 primary issue 留 comment,列出所有 tracking refs
-bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $PRIMARY_NUM --repo $PRIMARY_REPO --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"} --body "$(cat <<EOF
+bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $PRIMARY_NUM --repo $PRIMARY_REPO --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"} --body "$(cat <<EOF
 Tracked in:
 $(for ref in "${TRACKING_REFS[@]}"; do echo "- $ref"; done)
 EOF
@@ -887,7 +887,7 @@ done
 # 編輯 issue body 加入所有附件的 markdown link / 圖片嵌入
 # - .png/.jpg/.gif → ![desc](url)  讓 issue 直接渲染
 # - .pdf/.docx/其他 → [desc](url)  讓使用者點下載
-bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NUMBER --repo $GITHUB_REPO --body "..." --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
+bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NUMBER --repo $GITHUB_REPO --body "..." --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
 ```
 
 #### 命名規則
@@ -927,7 +927,7 @@ gh api repos/$GITHUB_REPO/milestones \
 # 所有剛建立的 issues 都指派到此 milestone
 for n in $ALL_ISSUE_NUMBERS; do
   # metadata-only edit (no drafted body) — still routes through the gate for uniform egress (#202)
-  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $n --repo $GITHUB_REPO --milestone "$MILESTONE_NAME" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
+  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $n --repo $GITHUB_REPO --milestone "$MILESTONE_NAME" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
 done
 ```
 
@@ -974,7 +974,7 @@ else
 | (deferred) | /idd-clarify invocation failed | Run /idd-clarify #$NEW_ISSUE_NUMBER manually to populate | deferred |
 "
     NEW_BODY="${CURRENT_BODY}${DEFERRED_BLOCK}"
-    bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NEW_ISSUE_NUMBER --repo $GITHUB_REPO --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
+    bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NEW_ISSUE_NUMBER --repo $GITHUB_REPO --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}
     echo "⚠ /idd-clarify failed (exit $CLARIFY_EXIT) — appended deferred placeholder; continuing to Step 4.7" >&2
   fi
 fi
@@ -1351,9 +1351,9 @@ drafted body（含 footer）在 dispatch 前過 repo-aware privacy gate:
 
 | Action | Command |
 |--------|---------|
-| `create` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create --title ... --body ... --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}`(body 含 footer) |
-| `comment` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $N --body ... --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}`(body 含 footer) |
-| `edit` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $N --body "$NEW_BODY_WITH_FOOTER" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}` |
+| `create` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create --title ... --body ... --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}`(body 含 footer) |
+| `comment` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $N --body ... --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}`(body 含 footer) |
+| `edit` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $N --body "$NEW_BODY_WITH_FOOTER" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested="$MENTION_ATTESTED"}` |
 | `update` | call `idd-update` skill on #N |
 | `skip` | no-op |
 | `merged-into` | no separate dispatch(content 已在 partner action body) |

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -344,7 +344,7 @@ basename、非公開 collaborator 真名、未發表 context)。**人名由 cont
 
 ```bash
 bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" <create|comment|edit> <原本的 gh args…> \
-  --scrub-attested "$SCRUB_LEVEL"
+  --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
 ```
 
 wrapper deterministically enforce「自審跑過」(缺 `--scrub-attested` → refuse,
@@ -528,6 +528,7 @@ echo "  3) 全部存好後告訴我「ok」，skill 會接手 upload + 嵌入 is
 3. **Priority** — P0（立即）/ P1（本週）/ P2（排程）/ P3（有空再做）
 4. **Description** — 問題描述（bug: 重現步驟 + expected + actual；feature: 需求 + 目的）
 5. **Stakeholders（v2.32.0+，可選）** — 若需要在 issue body 中 tag 人，使用 `--mention <login>[,<login>...]` flag 或自然語言（"tag X"）。**任何 @xxx 必走 [`rules/tagging-collaborators.md`](../../rules/tagging-collaborators.md) 5 步協定**（gh api → fuzzy match → AskUserQuestion fallback → @login 不用 display name → post 前 verify）。違反 = 通知錯人，不可逆。派送時把 resolved logins 帶進 `gh-egress.sh --mention-attested <login1,login2>`（#117 unconditional mention net）；非 mention 的附帶 `@xxx` token 一律 backtick-escape。
+   實作：resolution 完成後設 `MENTION_ATTESTED="login1,login2"`（無 mention 時留空 — 模板的 `${MENTION_ATTESTED:+...}` 條件式自動省略 flag）。
 
 #### Step 2.0.5: Title sanitization (v2.46.0+, P9 follow-up of #1)
 
@@ -619,7 +620,7 @@ if new_match exists AND new_match != tentative_default:
 bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create \
   --repo $GITHUB_REPO \
   --title "$TITLE" \
-  --scrub-attested "$SCRUB_LEVEL" \
+  --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"} \
   --body "$(cat <<'EOF'
 ## Problem
 
@@ -700,7 +701,7 @@ else
   # Algorithm: append to first contiguous "- [ ]"/"- [x]" section, OR append fresh `## Children` anchor
   NEW_BODY=$(append_to_task_list "$PARENT_BODY" "$ENTRY")
 
-  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$PARENT_NUM" --repo "$GITHUB_REPO" --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL"
+  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$PARENT_NUM" --repo "$GITHUB_REPO" --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
 fi
 ```
 
@@ -717,7 +718,7 @@ for M in $(echo "$BLOCKED_BY_LIST" | tr ',' '\n'); do
   BLOCKED_BLOCKQUOTE="${BLOCKED_BLOCKQUOTE}> Blocked by #${M}\n"
 done
 NEW_CHILD_BODY="${BLOCKED_BLOCKQUOTE}\n${ORIGINAL_BODY}"
-bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$CHILD_NUM" --repo "$GITHUB_REPO" --body "$NEW_CHILD_BODY" --scrub-attested "$SCRUB_LEVEL"
+bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit "$CHILD_NUM" --repo "$GITHUB_REPO" --body "$NEW_CHILD_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
 
 # Layer 1:GraphQL native dependency(嘗試,失敗不 abort)
 CHILD_NODE_ID=$(gh issue view "$CHILD_NUM" --repo "$GITHUB_REPO" --json id --jq '.id')
@@ -751,7 +752,7 @@ fi
 EPIC_NUM=$(bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create --repo "$GITHUB_REPO" \
   --title "$EPIC_TITLE" \
   --body "Epic for ${#ITEMS[@]}-item bundle (${BUNDLE_MODE})\n\n## Children\n" \
-  --label "epic" --scrub-attested "$SCRUB_LEVEL" | basename)
+  --label "epic" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"} | basename)
 
 # 2. 建 N children,逐個 auto-apply --parent <epic> + (ordered 時)--blocked-by <prev>
 PREV_CHILD=""
@@ -810,7 +811,7 @@ PRIMARY_URL=$(bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create \
   --repo $PRIMARY_REPO \
   --title "$TITLE" \
   --body "$FULL_BODY" \
-  --label "$TYPE" --scrub-attested "$SCRUB_LEVEL")
+  --label "$TYPE" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"})
 PRIMARY_NUM=$(basename "$PRIMARY_URL")
 
 # 2. 在每個 tracking repo 建追蹤 issue
@@ -830,13 +831,13 @@ ${FULL_BODY}"
     --repo $TRACKING_REPO \
     --title "$TITLE" \
     --body "$TRACKING_BODY" \
-    --label "$TYPE" --scrub-attested "$SCRUB_LEVEL")
+    --label "$TYPE" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"})
   TRACKING_NUM=$(basename "$TRACKING_URL")
   TRACKING_REFS+=("${TRACKING_REPO}#${TRACKING_NUM}")
 done
 
 # 3. 在 primary issue 留 comment,列出所有 tracking refs
-bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $PRIMARY_NUM --repo $PRIMARY_REPO --scrub-attested "$SCRUB_LEVEL" --body "$(cat <<EOF
+bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $PRIMARY_NUM --repo $PRIMARY_REPO --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"} --body "$(cat <<EOF
 Tracked in:
 $(for ref in "${TRACKING_REFS[@]}"; do echo "- $ref"; done)
 EOF
@@ -886,7 +887,7 @@ done
 # 編輯 issue body 加入所有附件的 markdown link / 圖片嵌入
 # - .png/.jpg/.gif → ![desc](url)  讓 issue 直接渲染
 # - .pdf/.docx/其他 → [desc](url)  讓使用者點下載
-bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NUMBER --repo $GITHUB_REPO --body "..." --scrub-attested "$SCRUB_LEVEL"
+bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NUMBER --repo $GITHUB_REPO --body "..." --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
 ```
 
 #### 命名規則
@@ -926,7 +927,7 @@ gh api repos/$GITHUB_REPO/milestones \
 # 所有剛建立的 issues 都指派到此 milestone
 for n in $ALL_ISSUE_NUMBERS; do
   # metadata-only edit (no drafted body) — still routes through the gate for uniform egress (#202)
-  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $n --repo $GITHUB_REPO --milestone "$MILESTONE_NAME" --scrub-attested "$SCRUB_LEVEL"
+  bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $n --repo $GITHUB_REPO --milestone "$MILESTONE_NAME" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
 done
 ```
 
@@ -973,7 +974,7 @@ else
 | (deferred) | /idd-clarify invocation failed | Run /idd-clarify #$NEW_ISSUE_NUMBER manually to populate | deferred |
 "
     NEW_BODY="${CURRENT_BODY}${DEFERRED_BLOCK}"
-    bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NEW_ISSUE_NUMBER --repo $GITHUB_REPO --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL"
+    bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $NEW_ISSUE_NUMBER --repo $GITHUB_REPO --body "$NEW_BODY" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}
     echo "⚠ /idd-clarify failed (exit $CLARIFY_EXIT) — appended deferred placeholder; continuing to Step 4.7" >&2
   fi
 fi
@@ -1350,9 +1351,9 @@ drafted body（含 footer）在 dispatch 前過 repo-aware privacy gate:
 
 | Action | Command |
 |--------|---------|
-| `create` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create --title ... --body ... --scrub-attested "$SCRUB_LEVEL"`(body 含 footer) |
-| `comment` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $N --body ... --scrub-attested "$SCRUB_LEVEL"`(body 含 footer) |
-| `edit` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $N --body "$NEW_BODY_WITH_FOOTER" --scrub-attested "$SCRUB_LEVEL"` |
+| `create` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" create --title ... --body ... --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}`(body 含 footer) |
+| `comment` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" comment $N --body ... --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}`(body 含 footer) |
+| `edit` | `bash "$CLAUDE_PLUGIN_ROOT/scripts/gh-egress.sh" edit $N --body "$NEW_BODY_WITH_FOOTER" --scrub-attested "$SCRUB_LEVEL" ${MENTION_ATTESTED:+--mention-attested "$MENTION_ATTESTED"}` |
 | `update` | call `idd-update` skill on #N |
 | `skip` | no-op |
 | `merged-into` | no separate dispatch(content 已在 partner action body) |


### PR DESCRIPTION
Refs #203
Refs #117

## Summary
gh-egress privacy gate 的 cluster 硬化（same-file bundle per batch-and-cluster.md）：

- **#203** mechanical-net 精修 6 項：移除 bare-filename 誤殺網（公開檔名 ≠ 洩漏）、content net 收斂 projects object（jq fail-closed + 寬網 fallback）、不可掃 body-file refuse（exit 5，修掉原「未掃即發」fail-open）、`${HOME:-}` guard、phantom-arg 修正、split-token attestation refuse
- **#117** unconditional @-mention net：fence/inline-code/dotted-host-URL 剝除後掃 `@login`，未被 `--mention-attested`（新 flag，5-step 協定產物）涵蓋即 refuse；entity-encoded 變體同擋；tagging rule 改 unconditional（escape-or-attest）；idd-issue 模板 zsh-safe `=`-form 接線 ×14

## Verification
三輪對抗收斂（R1: 4 lens + DA → DA-r2 → R2: 2 combined lens），**verify-gated PASS**，測試 19 → 54 assertions 全綠。11 項 findings：8 fixed（4d2e87b / c6fa9a0 / c9a92ed）、1 accepted-documented、2 follow-up（#226 #227）。另 file #225（掃描邊界 taxonomy）、#228（verify diff-freshness gate — 本次 DA 抓到的 mid-review commit 事故之結構性預防）。Codex cross-model lens 因 429 quota 缺席本輪（process gap 已記入 report，不冒充 6-AI）。詳見 #203 的 Verify Report comment。

## Checklist
- [x] Diagnose ×2
- [x] Implement（5 commits）
- [x] Verify ✓（三輪；in-scope fixes 含於本 PR）
- [x] **Verify-gated**: verify PASS — ready to merge → after merge, run /idd-close to finalize these issues (manual gate + closing summary; no auto-close trailer)

---
🤖 Generated by /idd-all cluster mode. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves) — IDD discipline requires manual /idd-close after merge to enforce checklist gate + closing summary.
