### PR TITLE
test: merge-completeness fixtures default-branch self-sufficiency

### DIFF
--- a/.claude/.idd/attachments/issue-224/_manifest.json
+++ b/.claude/.idd/attachments/issue-224/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 224,
+  "fetched_at": "2026-07-06T04:21:43Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/plugins/issue-driven-dev/scripts/tests/merge-completeness/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/merge-completeness/test.sh
@@ -25,6 +25,10 @@ mk_repo() {
   git -C "$d" config commit.gpgsign false
   printf 'base\n' > "$d/base.txt"
   git -C "$d" add -A && git -C "$d" commit -qm base
+  # Fixtures reference `main` explicitly; machines with unset init.defaultBranch
+  # (git default: master — most CI runners too) would 6/7 false-FAIL without
+  # this self-sufficient rename (idempotent when already main). Refs #224.
+  git -C "$d" branch -M main
   echo "$d"
 }
 


### PR DESCRIPTION
Refs #224

## Summary
merge-completeness 測試 fixtures 自足化：`mk_repo()` 首次 commit 後 `git branch -M main`，不再依賴機器層 `init.defaultBranch` 設定（unset 機器/CI runner 原本 6/7 false FAIL）。#217（CI）的 blocker。

## Verification
Reproduction-based PASS：unset-config 機器 1/7 → 7/7；helper rigidity probe 確認 fix 不遮蔽產品層假設。詳見 issue #224 Verify comment。

## Checklist
- [x] Diagnose / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize this issue

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
