### PR TITLE
feat: check-plugin-presence installed-but-disabled detection (exit 3 + enable hint)

### DIFF
--- a/.claude/.idd/attachments/issue-212/_manifest.json
+++ b/.claude/.idd/attachments/issue-212/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 212,
+  "fetched_at": "2026-07-05T15:23:33Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/plugins/issue-driven-dev/scripts/check-plugin-presence.sh
+++ b/plugins/issue-driven-dev/scripts/check-plugin-presence.sh
@@ -17,10 +17,12 @@
 #     version, per spec superpowers-integration "Dual pre-flight at delegation sites")
 #
 # Exit:
-#   0 — plugin installed, and skill present when a skill-name was given
-#       (or IDD_SKIP_PLUGIN_CHECK=1)
+#   0 — plugin installed + enabled (or enabled-state inconclusive → disk
+#       evidence only, warning printed; or IDD_SKIP_PLUGIN_CHECK=1)
 #   1 — plugin missing, or skill missing from the highest installed version
 #   2 — usage error (wrong arg count, or invalid skill name)
+#   3 — plugin installed but DISABLED (#212) — Skill() would fail; stderr
+#       prints the one-step `claude plugin enable` command
 #
 # Detect path is hardcoded against Claude Code 2025-Q4 plugin cache schema.
 # When schema changes upstream, see #35 (path schema watch-list).
@@ -42,12 +44,13 @@
 # Future hardening (#41 reopen criteria): if multi-user / CI deployment becomes
 # common, evaluate hash verification step against marketplace-published manifest.
 #
-# Presence ≠ enabled (#209 R1 verify F10, DA finding): this script checks the
-# on-disk cache only. A plugin that is installed but DISABLED still passes;
-# the later Skill() invocation resolves against the enabled/active version and
-# will fail. If a delegation fails right after this pre-flight passed, run:
-#   claude plugin enable <plugin>@<marketplace>
-# Enabled-state detection is tracked as a follow-up issue.
+# Presence + enabled (#209 F10 → #212): beyond the on-disk cache, this script
+# queries `claude plugin list --json` (documented CLI: code.claude.com
+# plugins-reference "plugin list — List installed plugins with their version,
+# source marketplace, and enable status"; JSON fields `id`/`enabled`/`installPath`
+# observed live 2026-07-05) and refuses (exit 3) when the plugin is installed
+# but DISABLED. CLI absent / query failure → graceful degrade to disk evidence
+# with a printed warning (fail-open floor — same philosophy as the #183 lock).
 
 set -u
 
@@ -98,6 +101,44 @@ if [ "${IDD_SKIP_PLUGIN_CHECK:-}" = "1" ]; then
   exit 0
 fi
 
+# Enabled-state detection (#212). Called just before every success exit —
+# disk evidence proves INSTALLED; Skill() resolves against ENABLED state.
+check_enabled_state() {
+  command -v claude >/dev/null 2>&1 || {
+    echo "⚠ claude CLI not on PATH — enabled-state check skipped (disk evidence only)." >&2; return 0; }
+  command -v python3 >/dev/null 2>&1 || {
+    echo "⚠ python3 not on PATH — enabled-state check skipped (disk evidence only)." >&2; return 0; }
+  local list_json verdict
+  if ! list_json="$(claude plugin list --json 2>/dev/null)"; then
+    echo "⚠ 'claude plugin list --json' failed — enabled-state check skipped (disk evidence only)." >&2
+    return 0
+  fi
+  verdict="$(printf '%s' "$list_json" | python3 -c '
+import json, sys
+target = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("parse-error"); raise SystemExit
+for p in (data if isinstance(data, list) else []):
+    if p.get("id") == target:
+        print("true" if p.get("enabled") else "false"); break
+else:
+    print("absent")
+' "${PLUGIN}@${MARKETPLACE}" 2>/dev/null || echo "parse-error")"
+  case "$verdict" in
+    true) return 0 ;;
+    false)
+      echo "✗ ${PLUGIN}@${MARKETPLACE} is installed but DISABLED — Skill() resolution will fail." >&2
+      echo "  Enable it (one step):" >&2
+      echo "    claude plugin enable ${PLUGIN}@${MARKETPLACE}" >&2
+      exit 3 ;;
+    *)
+      echo "⚠ enabled-state check inconclusive (${verdict}) — proceeding on disk evidence only." >&2
+      return 0 ;;
+  esac
+}
+
 # Plugin cache layout (Claude Code 2025-Q4):
 #   ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/.claude-plugin/plugin.json
 # Match any installed version under the plugin dir.
@@ -109,8 +150,8 @@ files=( "${HOME}/.claude/plugins/cache/${MARKETPLACE}/${PLUGIN}"/*/.claude-plugi
 shopt -u nullglob
 
 if (( ${#files[@]} > 0 )); then
-  # Plugin present. Without a skill arg we are done (2-arg backward-compat path).
-  [ -z "$SKILL" ] && exit 0
+  # Plugin present. Without a skill arg, enabled-state is the last gate (#212).
+  if [ -z "$SKILL" ]; then check_enabled_state; exit 0; fi
 
   # Skill-level pre-flight (#209): resolve the HIGHEST installed version via
   # sort -V (same resolution rule as the pai canonical chain in idd-verify D1)
@@ -122,6 +163,7 @@ if (( ${#files[@]} > 0 )); then
   # highest-version resolution and false-negative the skill check.
   latest=$(printf '%s\n' "${files[@]}" | sed 's|\.claude-plugin/plugin\.json$||' | sort -V | tail -1)
   if [ -f "${latest}skills/${SKILL}/SKILL.md" ]; then
+    check_enabled_state
     exit 0
   fi
   cat >&2 <<EOF

--- a/plugins/issue-driven-dev/scripts/tests/check-plugin-presence/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/check-plugin-presence/test.sh
@@ -33,9 +33,27 @@ mk_plugin() { # home marketplace plugin version [skill...]
   done
 }
 
-run() { # home [args...] — runs script with fake HOME, captures stderr to $ERR
+mk_claude_shim() { # home json — installs a fake `claude` CLI printing $json for `plugin list --json`
+  local home="$1" json="$2"
+  mkdir -p "$home/bin"
+  cat > "$home/bin/claude" <<SHIM
+#!/usr/bin/env bash
+if [ "\$1" = "plugin" ] && [ "\$2" = "list" ]; then printf '%s' '$json'; exit 0; fi
+exit 2
+SHIM
+  chmod +x "$home/bin/claude"
+}
+
+run() { # home [args...] — fake HOME + hermetic claude shim (default: empty list)
   local home="$1"; shift
-  ERR=$(HOME="$home" IDD_SKIP_PLUGIN_CHECK= bash "$SCRIPT" "$@" 2>&1 >/dev/null)
+  [ -x "$home/bin/claude" ] || mk_claude_shim "$home" "[]"
+  ERR=$(HOME="$home" PATH="$home/bin:$PATH" IDD_SKIP_PLUGIN_CHECK= bash "$SCRIPT" "$@" 2>&1 >/dev/null)
+  return $?
+}
+
+run_noclaude() { # home [args...] — PATH without any claude CLI
+  local home="$1"; shift
+  ERR=$(HOME="$home" PATH="/usr/bin:/bin" IDD_SKIP_PLUGIN_CHECK= bash "$SCRIPT" "$@" 2>&1 >/dev/null)
   return $?
 }
 
@@ -132,5 +150,46 @@ run "$H" claude-plugins-official ".."
 assert_exit "R2: bare .. plugin → 2" 2 $?
 run "$H" claude-plugins-official "..."
 assert_exit "R2: dot-only plugin (...) → 2" 2 $?
+
+
+# --- #212 enabled-state detection --------------------------------------------
+# enabled=true → pass
+H="$(mk_home)"; mk_plugin "$H" claude-plugins-official superpowers 4.1.0
+mk_claude_shim "$H" '[{"id":"superpowers@claude-plugins-official","enabled":true,"installPath":"'"$H"'/.claude/plugins/cache/claude-plugins-official/superpowers/4.1.0"}]'
+run "$H" claude-plugins-official superpowers
+assert_exit "#212: installed + enabled → 0" 0 $?
+
+# enabled=false → exit 3 + enable hint
+H="$(mk_home)"; mk_plugin "$H" claude-plugins-official superpowers 4.1.0
+mk_claude_shim "$H" '[{"id":"superpowers@claude-plugins-official","enabled":false,"installPath":"x"}]'
+run "$H" claude-plugins-official superpowers
+assert_exit "#212: installed but DISABLED → 3" 3 $?
+assert_grep "#212 disabled: stderr has enable cmd" "claude plugin enable superpowers@claude-plugins-official" "$ERR"
+
+# claude CLI absent → graceful degrade (disk evidence), exit 0 + warning
+H="$(mk_home)"; mk_plugin "$H" claude-plugins-official superpowers 4.1.0
+run_noclaude "$H" claude-plugins-official superpowers
+assert_exit "#212: claude CLI absent → degrade to disk check (0)" 0 $?
+assert_grep "#212 degrade: warning surfaced" "enabled-state check skipped" "$ERR"
+
+# list --json errors → degrade, exit 0 + warning
+H="$(mk_home)"; mk_plugin "$H" claude-plugins-official superpowers 4.1.0
+mkdir -p "$H/bin"; printf '#!/usr/bin/env bash\nexit 1\n' > "$H/bin/claude"; chmod +x "$H/bin/claude"
+run "$H" claude-plugins-official superpowers
+assert_exit "#212: plugin list --json fails → degrade (0)" 0 $?
+assert_grep "#212 cli-fail: warning surfaced" "enabled-state check skipped" "$ERR"
+
+# plugin on disk but absent from list → warn + proceed (fail-open floor)
+H="$(mk_home)"; mk_plugin "$H" claude-plugins-official superpowers 4.1.0
+mk_claude_shim "$H" '[]'
+run "$H" claude-plugins-official superpowers
+assert_exit "#212: on disk but absent from list → proceed (0)" 0 $?
+assert_grep "#212 absent: inconclusive warning" "inconclusive" "$ERR"
+
+# disabled check still respects skill-level pre-flight ordering (missing skill wins with 1)
+H="$(mk_home)"; mk_plugin "$H" claude-plugins-official superpowers 4.1.0
+mk_claude_shim "$H" '[{"id":"superpowers@claude-plugins-official","enabled":false}]'
+run "$H" claude-plugins-official superpowers no-such-skill
+assert_exit "#212: missing skill (1) precedes disabled (3)" 1 $?
 
 print_summary "check-plugin-presence"

--- a/plugins/issue-driven-dev/skills/idd-diagnose/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-diagnose/SKILL.md
@@ -232,7 +232,7 @@ Exit code:
   claude-plugins-official superpowers systematic-debugging || exit 1
 ```
 
-缺 plugin 或缺目標 skill → helper 印出含一步安裝指令（`claude plugin install superpowers@claude-plugins-official`）的錯誤，**立即 abort**。不做內建 fallback、不 silent degrade（#209 D2）。**注意（#209 R1 verify F10）**：pre-flight 驗的是磁碟 cache 存在；plugin 被 disable 時仍會通過、隨後 `Skill()` 才失敗 — 此時跑 `claude plugin enable superpowers@claude-plugins-official`。
+缺 plugin 或缺目標 skill → helper 印出含一步安裝指令（`claude plugin install superpowers@claude-plugins-official`）的錯誤，**立即 abort**。不做內建 fallback、不 silent degrade（#209 D2）。**注意（#209 F10 → #212 已解）**：pre-flight 現亦查 `claude plugin list --json` 的 enabled 狀態 — installed-but-disabled 會在 pre-flight 即 exit 3 並印一步 `claude plugin enable` 指令；claude CLI 缺席時 graceful degrade 回磁碟檢查（警告可見）。
 
 **執行框架 = `superpowers:systematic-debugging`（canonical process source）**：invoke `Skill(skill="superpowers:systematic-debugging")`，依其紀律完成重現 → trace → 假設形成（一次一個假設、證據先於修法）。IDD 不再內嵌自己的 RCA 步驟敘述 — 除錯 process 以 superpowers 為 single source（#209 D3）。
 

--- a/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
@@ -401,7 +401,7 @@ gh issue comment $NUMBER --repo $GITHUB_REPO --body "$IMPLEMENTATION_PLAN"
 
 缺 plugin 或缺目標 skill → helper 印出含一步安裝指令（`claude plugin install superpowers@claude-plugins-official`）的錯誤，**立即 abort**。不做 vendored fallback、不 silent degrade（#209 D2）— superpowers 是 install-time hard dependency（plugin.json `dependencies` 已宣告，正常安裝下必在；缺席代表安裝壞了，該修安裝而不是繞過紀律）。
 
-**適用範圍（#209 R1 verify F8）**：pre-flight 針對會走 TDD delegation 的 code 變更項；若本次變更清單**全部**屬下方「IDD 專屬路由例外」（純 prose / `with_skill`），此 pre-flight 可跳過 — 該路由本來就不 invoke superpowers。**注意（F10）**：pre-flight 驗的是磁碟 cache 存在；plugin 被 disable 時仍會通過、隨後 `Skill()` 才失敗 — 此時跑 `claude plugin enable superpowers@claude-plugins-official`。
+**適用範圍（#209 R1 verify F8）**：pre-flight 針對會走 TDD delegation 的 code 變更項；若本次變更清單**全部**屬下方「IDD 專屬路由例外」（純 prose / `with_skill`），此 pre-flight 可跳過 — 該路由本來就不 invoke superpowers。**注意（F10 → #212 已解）**：pre-flight 現亦查 enabled 狀態 — disabled 會在 pre-flight 即 exit 3 並印 enable 指令；CLI 缺席時 graceful degrade 回磁碟檢查。
 
 每個變更項依序執行：
 


### PR DESCRIPTION
Refs #212

## Summary
check-plugin-presence.sh 補上 enabled-state 機械偵測（#209 F10 的 follow-up）：`claude plugin list --json`（documented CLI，官方文檔已 cross-check）的 `.enabled` — installed-but-disabled 於 pre-flight 即 exit 3 + 一步 enable 指令，不再讓 Skill() 才爆。CLI/python3 缺席或查詢失敗 → graceful degrade 回磁碟檢查（警告可見）。測試 hermetic 化（PATH shim，不打真 CLI）+ 6 新 case。

## Verification
34/34 tests；六行為分支全覆蓋；F10 notes 同步。詳見 issue #212 Verify comment。

## Checklist
- [x] Diagnose / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize this issue

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
