### PR TITLE
feat: assert-helpers eval-content ban + safe output-grep helper pair

### DIFF
--- a/.claude/.idd/attachments/issue-188/_manifest.json
+++ b/.claude/.idd/attachments/issue-188/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 188,
+  "fetched_at": "2026-07-05T22:30:16Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/plugins/issue-driven-dev/scripts/lib/assert-helpers.sh
+++ b/plugins/issue-driven-dev/scripts/lib/assert-helpers.sh
@@ -14,6 +14,15 @@
 # the `--` end-of-options separator so a `--`-prefixed needle can never be
 # misparsed as a grep flag — the #154/#160 bug class, made unrepresentable.
 #
+# EVAL-CONTENT BAN (#188, detonated in #186 f4b): with the eval family
+# (assert_true), never interpolate captured output into the eval string —
+# output containing a literal $VAR (e.g. a script printing
+# "$CLAUDE_PLUGIN_ROOT/...") gets RE-EXPANDED by eval and explodes under the
+# runner's `set -u` (unbound variable → the assertion false-FAILs). Safe forms:
+#   - write output to a file, then assert_output_grep / refute_output_grep
+#   - or assert_grep "name" "$needle" "$captured"   (string haystack, no eval)
+# assert_true is for command CONDITIONS you author, never for data you captured.
+#
 # Counters are module-level (PASS / FAIL / FAILURES); the sourcing runner does
 # not declare them. `set -u`-safe.
 
@@ -53,6 +62,21 @@ refute_grep() { # name needle haystack
 # Regex variant when the needle is an ERE pattern (still `--`-safe for the pattern).
 assert_grep_re() { # name ere_pattern haystack
   if printf '%s\n' "$3" | grep -qE -- "$2"; then pass "$1"; else fail "$1" "pattern not matched: [$2]"; fi
+}
+
+# ── output-file grep family (#188 — the safe form for captured output) ──
+# assert_output_grep : file MUST contain needle (fixed-string, `--`-safe).
+# refute_output_grep : file MUST NOT contain needle.
+# Reading via grep FILE (no eval, no interpolation) keeps literal $VAR content
+# in the output inert. A missing/unreadable file FAILS loudly on both helpers —
+# an unreadable capture is a broken test, never a silent pass.
+assert_output_grep() { # name needle file
+  if [ ! -r "$3" ]; then fail "$1" "output file missing/unreadable: $3"; return; fi
+  if grep -qF -- "$2" "$3"; then pass "$1"; else fail "$1" "needle not found in $3: [$2]"; fi
+}
+refute_output_grep() { # name needle file
+  if [ ! -r "$3" ]; then fail "$1" "output file missing/unreadable: $3"; return; fi
+  if grep -qF -- "$2" "$3"; then fail "$1" "needle unexpectedly found in $3: [$2]"; else pass "$1"; fi
 }
 
 # ── filesystem family ──

--- a/plugins/issue-driven-dev/scripts/tests/assert-helpers/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/assert-helpers/test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# test.sh — self-tests for assert-helpers.sh, focused on the #188 eval-content
+# class: captured output containing literal $VAR must be safe to assert on.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert-helpers.sh"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# fixture: output containing a literal unset $VAR (the process-attachments
+# message shape that detonated #186's f4b under eval + set -u)
+printf 'run %s/scripts/tool.sh to retry\n' '$CLAUDE_PLUGIN_ROOT' > "$WORK/out.txt"
+
+# 1. assert_output_grep finds a needle in a file whose content has literal $VAR
+assert_output_grep "output-grep: literal \$VAR content is inert" '$CLAUDE_PLUGIN_ROOT/scripts' "$WORK/out.txt"
+
+# 2. refute_output_grep — absent needle passes
+refute_output_grep "refute-output-grep: absent needle" 'no-such-string' "$WORK/out.txt"
+
+# 3. needle starting with -- is data, not a grep flag (inherited #156 discipline)
+printf -- '--state closed\n' > "$WORK/dash.txt"
+assert_output_grep "output-grep: --needle is data" '--state closed' "$WORK/dash.txt"
+
+# 4. missing file fails loudly (not silently passing)
+OUT_BEFORE=$FAIL
+refute_output_grep "missing-file probe" 'x' "$WORK/nonexistent.txt" 2>/dev/null || true
+if [ "$FAIL" -gt "$OUT_BEFORE" ]; then
+  # the probe registered a failure — convert to a pass for THIS meta-assertion
+  FAIL=$((FAIL - 1)); unset 'FAILURES[${#FAILURES[@]}-1]' 2>/dev/null
+  pass "missing file → loud failure (not silent pass)"
+else
+  fail "missing file → loud failure (not silent pass)" "helper silently passed on missing file"
+fi
+
+# 5. header documents the eval-content ban
+assert_output_grep "header carries eval-content warning" 'never interpolate captured output' "$HERE/../../lib/assert-helpers.sh"
+
+print_summary "assert-helpers"


### PR DESCRIPTION
Refs #188

## Summary
assert-helpers.sh 的 eval-content 禁忌文件化（#186 f4b 事故 class）+ `assert_output_grep`/`refute_output_grep` 安全成對 helper（fixed-string、`--`-safe、missing-file loud-fail）+ 新 self-test suite（5 斷言，含字面 `$VAR` inert 證明）。

## Verification
Self-test 5/5 RED→GREEN；既有 consumer 回歸不變。詳見 issue #188 Verify comment。

## Checklist
- [x] Diagnose / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize this issue

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
