### PR TITLE
feat: test-suite aggregator + CI workflow (drift-guard enforcement last mile)

### DIFF
--- a/.claude/.idd/attachments/issue-217/_manifest.json
+++ b/.claude/.idd/attachments/issue-217/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 217,
+  "fetched_at": "2026-07-05T22:32:39Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+# tests.yml — run every fixture suite on push + PR (#217).
+# The enforcement link for the repo's drift-guard hard locks: suites only
+# guarded what someone remembered to run (#214 R2 DA finding 15).
+#
+# NOTE: init.defaultBranch is deliberately NOT configured here — fixtures must
+# be self-sufficient (#224); masking that class in CI would hide real bugs.
+name: tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  suites:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run all fixture suites
+        run: bash plugins/issue-driven-dev/scripts/run-all-tests.sh

--- a/plugins/issue-driven-dev/scripts/run-all-tests.sh
+++ b/plugins/issue-driven-dev/scripts/run-all-tests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# run-all-tests.sh — aggregate entry for every fixture suite under
+# scripts/tests/*/test.sh (#217). This is the missing enforcement link for the
+# repo's drift-guard hard locks: suites existed but nothing ran them
+# automatically (#214 R2 DA finding 15).
+#
+# Behavior:
+#   - runs EVERY suite (no fail-fast) and prints a per-suite summary table
+#   - per-suite timeout (default 180s, IDD_SUITE_TIMEOUT to override) so a
+#     hung suite (FIFO writer class, #117 incident) cannot wedge CI
+#   - exit 0 iff every suite passed; 1 otherwise
+#
+# Env:
+#   IDD_TESTS_DIR      override the suites dir (aggregator self-tests use this)
+#   IDD_SUITE_TIMEOUT  per-suite seconds (default 180)
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TESTS_DIR="${IDD_TESTS_DIR:-$HERE/tests}"
+SUITE_TIMEOUT="${IDD_SUITE_TIMEOUT:-180}"
+
+if [ ! -d "$TESTS_DIR" ]; then
+  echo "✗ tests dir not found: $TESTS_DIR" >&2
+  exit 2
+fi
+
+run_with_timeout() { # seconds cmd... — portable watchdog (macOS has no coreutils timeout)
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+    return $?
+  fi
+  "$@" &
+  local pid=$!
+  ( sleep "$secs"; kill -TERM "$pid" 2>/dev/null ) &
+  local wd=$!
+  wait "$pid" 2>/dev/null
+  local rc=$?
+  kill -TERM "$wd" 2>/dev/null; wait "$wd" 2>/dev/null
+  return $rc
+}
+
+TOTAL=0; FAILED=0
+declare -a ROWS=()
+shopt -s nullglob
+for t in "$TESTS_DIR"/*/test.sh; do
+  name="$(basename "$(dirname "$t")")"
+  TOTAL=$((TOTAL + 1))
+  start=$(date +%s)
+  if run_with_timeout "$SUITE_TIMEOUT" bash "$t" > /tmp/idd-suite-"$name".log 2>&1; then
+    rc=0; verdict="PASS"
+  else
+    rc=$?; FAILED=$((FAILED + 1))
+    if [ "$rc" -ge 124 ]; then verdict="TIMEOUT(${SUITE_TIMEOUT}s)"; else verdict="FAIL(rc=$rc)"; fi
+  fi
+  dur=$(( $(date +%s) - start ))
+  ROWS+=("$(printf '%-32s %-14s %3ss' "$name" "$verdict" "$dur")")
+  # surface the tail of failing suites immediately (CI log ergonomics)
+  [ "$rc" -ne 0 ] && { echo "── $name output tail ──"; tail -15 /tmp/idd-suite-"$name".log; echo; }
+done
+shopt -u nullglob
+
+echo "══════ run-all-tests summary ══════"
+printf '%s\n' "${ROWS[@]:-"(no suites found)"}"
+echo "───────────────────────────────────"
+echo "suites: $TOTAL, failed: $FAILED"
+[ "$TOTAL" -gt 0 ] && [ "$FAILED" -eq 0 ]

--- a/plugins/issue-driven-dev/scripts/tests/run-all-tests-self/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/run-all-tests-self/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# test.sh — aggregator self-tests (#217): pass / fail / timeout branches.
+# NOTE: lives OUTSIDE the aggregator's default sweep only logically — the
+# aggregator WILL run this suite too; the fixtures below use IDD_TESTS_DIR to
+# point the aggregator at a sandbox, so no recursion occurs.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGG="$HERE/../../run-all-tests.sh"
+. "$HERE/../../lib/assert-helpers.sh"
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+
+mk_suite() { # name body
+  mkdir -p "$W/tests/$1"
+  printf '#!/usr/bin/env bash\n%s\n' "$2" > "$W/tests/$1/test.sh"
+}
+
+# all-pass → exit 0
+mk_suite ok 'exit 0'
+IDD_TESTS_DIR="$W/tests" bash "$AGG" > "$W/out1" 2>&1
+assert_exit "all-pass → 0" 0 $?
+assert_grep "summary lists suite" "ok" "$(cat "$W/out1")"
+
+# one failing → exit 1 + tail surfaced
+mk_suite bad 'echo boom-detail; exit 1'
+IDD_TESTS_DIR="$W/tests" bash "$AGG" > "$W/out2" 2>&1
+assert_exit "any-fail → 1" 1 $?
+assert_grep "failing tail surfaced" "boom-detail" "$(cat "$W/out2")"
+
+# hung suite → timeout branch, aggregator still completes
+rm -rf "$W/tests/bad"
+mk_suite hang 'sleep 30'
+IDD_TESTS_DIR="$W/tests" IDD_SUITE_TIMEOUT=2 bash "$AGG" > "$W/out3" 2>&1
+assert_exit "hung suite → 1 (timeout)" 1 $?
+assert_grep "timeout verdict shown" "TIMEOUT" "$(cat "$W/out3")"
+
+# empty dir → non-zero (zero suites must not read as success)
+mkdir -p "$W/empty"
+IDD_TESTS_DIR="$W/empty" bash "$AGG" > "$W/out4" 2>&1
+assert_exit "zero suites → non-zero" 1 $?
+
+print_summary "run-all-tests-self"


### PR DESCRIPTION
Refs #217

## Summary
測試套件的 enforcement 最後一哩（#214 R2 DA 抓到的缺口）：`run-all-tests.sh` 聚合器（no fail-fast、per-suite timeout watchdog、失敗 tail 即時浮出、零 suite 不算成功）+ GitHub Actions workflow（push/PR 觸發）。

**Merge 順序依賴**：CI 首綠需要 **PR #230**（#224 merge-completeness 環境假設修復）先 merge — 本 PR 的 13-suite 實跑證據中該 suite 如預期紅、其餘 12 綠。workflow 刻意不設 `init.defaultBranch`（在 CI 掩蓋 fixture 環境 bug 是反目標）。

## Verification
Self-test 7/7（pass/fail/timeout/empty 四分支）+ 13-suite 實跑。詳見 issue #217 Verify comment。

## Checklist
- [x] Diagnose / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge（after PR #230）→ after merge, run /idd-close to finalize this issue

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
