### PR TITLE
feat: submodule boundary detection in IDD config resolution (mechanism 3.5)

### DIFF
--- a/.claude/.idd/attachments/issue-162/_manifest.json
+++ b/.claude/.idd/attachments/issue-162/_manifest.json
@@ -1,0 +1,6 @@
+{
+  "issue": 162,
+  "fetched_at": "2026-07-05T22:48:06Z",
+  "fetched_by": "idd-diagnose",
+  "files": []
+}

--- a/plugins/issue-driven-dev/references/config-protocol.md
+++ b/plugins/issue-driven-dev/references/config-protocol.md
@@ -22,6 +22,9 @@ When an idd-* skill needs to determine the target repo, it walks this priority l
 1. --target <owner/repo> flag     ← runtime override (per invocation)
 2. ask_each_time + candidates     ← runtime menu (from config)
 3. Predicate match (when clauses) ← auto-pick candidate or group by context
+3.5 Submodule boundary (#162)     ← cwd inside a submodule → its own origin
+                                     overrides the parent config's github_repo
+                                     (unless "submodules": "off"); never silent
 4. Cascading config (walk up)     ← static routing by directory
 5. git remote fallback            ← last resort, with prompt
 ```
@@ -77,6 +80,28 @@ A single config can list multiple candidate repos. When `ask_each_time: true`, t
 - The chosen candidate's fields are used for that invocation only — config is NOT modified
 
 If `ask_each_time` is `false` or missing, the top-level `github_repo` wins by default. Candidates are ignored unless the user supplies `--target` matching a candidate label or repo.
+
+### Mechanism 3.5: Submodule boundary detection (#162)
+
+When the walk-up (mechanism 4) resolves a config that lives in a **parent
+repo** while `cwd` is inside a **git submodule**, the parent's `github_repo`
+would silently target the wrong repo (the pain point that motivated #162).
+Resolution therefore consults `scripts/lib/resolve-submodule-route.sh` before
+falling back to the config's bare `github_repo`:
+
+- `git rev-parse --show-superproject-working-tree` non-empty → inside a submodule
+- config key `"submodules"` (optional): `"auto"` (default) routes to the
+  **submodule's own origin**; `"off"` keeps the parent config's routing
+- **Never silent**: whichever way it routes, a surface line is printed when a
+  submodule boundary is crossed. A submodule without an `origin` remote (or a
+  non-`owner/repo`-shaped URL) falls back to the parent config with a warning.
+- Explicit mechanisms still win: `--target` (1) and matching `candidates`
+  predicates (2/3) take precedence — declare a `path_contains` candidate in the
+  parent config to pin a submodule to any repo regardless of this mechanism.
+
+**Backward-compat note**: repos that relied on "submodule cwd routes to the
+parent repo" must set `"submodules": "off"` (one line). The default flips to
+the submodule because the silent-wrong-repo direction is the bug class.
 
 ### Mechanism 4: Cascading config (walk-up)
 

--- a/plugins/issue-driven-dev/scripts/lib/resolve-submodule-route.sh
+++ b/plugins/issue-driven-dev/scripts/lib/resolve-submodule-route.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# resolve-submodule-route.sh — submodule boundary detection for IDD config
+# resolution (#162; config-protocol.md "Mechanism 3.5").
+#
+# Problem shape: cwd inside a git submodule → walk-up finds the PARENT repo's
+# config → its github_repo silently targets the parent, not the submodule.
+#
+# Contract:
+#   resolve_submodule_route <submodules_key_value>
+#     $1  the config's `submodules` value ("auto" when key absent)
+#   stdout: "owner/repo" of the SUBMODULE's origin when the boundary should
+#           override the parent config's github_repo; EMPTY otherwise
+#   stderr: a surface line whenever cwd IS inside a submodule (both routings) —
+#           the silent-wrong-repo failure is the bug class being closed, so
+#           the boundary is never crossed silently.
+#   exit:   always 0 (advisory resolver; caller falls through on empty stdout)
+#
+# Priority (per #162 diagnosis): explicit candidates (mechanism 3) already won
+# before this runs; this only overrides the bare parent `github_repo` default.
+resolve_submodule_route() {
+  local mode="${1:-auto}"
+  local super sub_url sub_repo
+  super="$(git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+  [ -z "$super" ] && return 0   # not inside a submodule — silent no-op
+
+  if [ "$mode" = "off" ]; then
+    echo "→ submodule detected (superproject: $super) — 'submodules: off' set; routing stays with the parent config's github_repo" >&2
+    return 0
+  fi
+
+  sub_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [ -z "$sub_url" ]; then
+    echo "⚠ submodule detected but it has no 'origin' remote — falling back to the parent config's github_repo" >&2
+    return 0
+  fi
+  sub_repo="$(printf '%s' "$sub_url" | sed -E 's#(\.git)?$##; s#.*[:/]([^/]+/[^/]+)$#\1#')"
+  if ! printf '%s' "$sub_repo" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+    echo "⚠ submodule origin URL did not yield owner/repo shape ('$sub_repo') — falling back to parent config" >&2
+    return 0
+  fi
+  echo "→ submodule detected: routing to $sub_repo (submodule origin). Parent config would target its own github_repo; set \"submodules\": \"off\" to keep parent routing." >&2
+  printf '%s\n' "$sub_repo"
+}

--- a/plugins/issue-driven-dev/scripts/tests/submodule-routing/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/submodule-routing/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# test.sh — fixtures for resolve-submodule-route.sh (#162)
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert-helpers.sh"
+. "$HERE/../../lib/resolve-submodule-route.sh"
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+
+mkrepo() { git -C "$1" init -q; git -C "$1" config user.email t@t.t; git -C "$1" config user.name t; git -C "$1" config commit.gpgsign false; git -C "$1" config protocol.file.allow always; }
+
+# fixture: parent repo with a submodule that has its own origin
+mkdir -p "$W/subsrc"; mkrepo "$W/subsrc"
+printf 'x\n' > "$W/subsrc/f"; git -C "$W/subsrc" add -A; git -C "$W/subsrc" commit -qm sub
+git -C "$W/subsrc" remote add origin git@github.com:acme/sub-repo.git
+
+mkdir -p "$W/parent"; mkrepo "$W/parent"
+printf 'p\n' > "$W/parent/p"; git -C "$W/parent" add -A; git -C "$W/parent" commit -qm parent
+git -C "$W/parent" -c protocol.file.allow=always submodule add -q "$W/subsrc" themodule 2>/dev/null
+git -C "$W/parent" commit -qm addsub
+# submodule clone keeps file:// origin — override to a github-shaped one
+git -C "$W/parent/themodule" remote set-url origin git@github.com:acme/sub-repo.git
+
+# 1. inside submodule + auto → sub repo on stdout + surface line
+OUT=$(cd "$W/parent/themodule" && resolve_submodule_route auto 2>"$W/err1")
+assert_eq "auto: routes to submodule origin" "acme/sub-repo" "$OUT"
+assert_grep "auto: surface line printed" "submodule detected" "$(cat "$W/err1")"
+
+# 2. inside submodule + off → empty stdout + surface line (never silent)
+OUT=$(cd "$W/parent/themodule" && resolve_submodule_route off 2>"$W/err2")
+assert_eq "off: stays with parent (empty stdout)" "" "$OUT"
+assert_grep "off: surface line still printed" "submodules: off" "$(cat "$W/err2")"
+
+# 3. not in a submodule → empty + silent
+OUT=$(cd "$W/parent" && resolve_submodule_route auto 2>"$W/err3")
+assert_eq "non-submodule: empty stdout" "" "$OUT"
+assert_eq "non-submodule: silent stderr" "" "$(cat "$W/err3")"
+
+# 4. submodule without origin → empty + warning fallback
+git -C "$W/parent/themodule" remote remove origin
+OUT=$(cd "$W/parent/themodule" && resolve_submodule_route auto 2>"$W/err4")
+assert_eq "no-origin: empty stdout (parent fallback)" "" "$OUT"
+assert_grep "no-origin: warning surfaced" "no 'origin' remote" "$(cat "$W/err4")"
+
+print_summary "submodule-routing"

--- a/plugins/issue-driven-dev/skills/idd-config/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-config/SKILL.md
@@ -43,6 +43,8 @@ allowed-tools:
 - `validate`
 - `which`
 
+> **Submodule boundary (#162)**：`which` 執行時同時跑 `scripts/lib/resolve-submodule-route.sh`（source 後呼叫 `resolve_submodule_route <submodules值>`）並顯示偵測結果 — cwd 在 submodule 內時，顯示將路由到 submodule origin 還是 parent config（依 `submodules` key，預設 `auto`）。
+
 **不做**（v2 再加）：
 - `set-target` / `add-candidate` / `add-group` / `remove-*` 等 mutating subcommands（先用直接編輯 JSON）
 - 全局 config（`~/.claude/issue-driven-dev.global.json`）— config-protocol 目前 only walked-up local config


### PR DESCRIPTION
Refs #162

## Summary
IDD config resolution 新增 Mechanism 3.5（submodule boundary）：cwd 在 submodule 內時路由到 submodule 自身 origin（`"submodules": "off"` 保留舊行為），**永不靜默跨界**（雙向 surface line）。Helper `lib/resolve-submodule-route.sh` + 8 斷言 fixture 測試 + red-proof。關閉「parent config 靜默吃掉 submodule 操作」的 bug class（2026-05-26 實戰 pain point）。

## Verification
Fixture 8/8（真 git super+sub）+ red-proof。詳見 issue #162 Verify comment。

## Checklist
- [x] Diagnose / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize this issue

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
