### PR TITLE
cluster: idd-all unattended contract — state-file signal, TTY heuristic removal, dependency early gates

### DIFF
--- a/plugins/issue-driven-dev/references/ic-r011-checkpoint.md
+++ b/plugins/issue-driven-dev/references/ic-r011-checkpoint.md
@@ -246,12 +246,12 @@ When detected, the skill reverts to the legacy 3-option ask path identically to 
 
 ### 5.4 Unattended mode fallback (no TTY + bypass set)
 
-When the skill detects `[ ! -t 0 ]` OR `IDD_ALL_UNATTENDED=1` AND `AI_LOW_BAR_ISSUE_FILING=false`:
+When the skill detects unattended mode（per `references/unattended-contract.md`：state file 或 `IDD_ALL_UNATTENDED=1`；TTY check 已廢除 #222）AND `AI_LOW_BAR_ISSUE_FILING=false`:
 - Skill cannot call AskUserQuestion (no TTY)
 - Skill SHALL apply **implicit (a) skip semantics** to all candidates
 - Audit trail: `Skipped (unattended mode + AI_LOW_BAR_ISSUE_FILING=false → implicit (a) skip)`
 
-When skill detects unattended mode WITHOUT env var bypass (just `IDD_ALL_UNATTENDED=1` or no TTY):
+When skill detects unattended mode WITHOUT env var bypass（unattended-contract 訊號本身）:
 - Default file path proceeds (it's non-blocking by design — no AskUserQuestion in default file path)
 
 ### 5.5 Both layers active

--- a/plugins/issue-driven-dev/references/unattended-contract.md
+++ b/plugins/issue-driven-dev/references/unattended-contract.md
@@ -1,0 +1,33 @@
+# Unattended contract — setter / detector / cleanup（#123, v2.92.0+）
+
+> **Normative**：跨 skill（含跨 plugin）判定「本 session 是否處於 unattended orchestration」的唯一可靠契約。TTY heuristic（`[ ! -t 0 ]`）在 Claude Code harness 內恆真（Bash tool 永無 TTY，#222 實證），**不得**作為 attended/unattended 判別依據——只在 standalone CLI（真 terminal）場景可作輔助訊號。
+
+## 訊號（優先序）
+
+1. **State file** `.claude/.idd/state/unattended.json`（primary，harness 內跨 tool-call 持久）
+   - Schema：`{"active":true,"by":"idd-all","started_at":"<UTC ISO8601>"}`
+   - **TTL 24h**：`started_at` 超齡或檔案損毀 → 視為 stale，偵測方警告 + 自動清除 + 判 ATTENDED（crashed orchestrator 不得讓後續 attended session 永久誤判）
+2. **Env var** `IDD_ALL_UNATTENDED=1`（compat layer — 給真 subprocess 的 hand-off，如 idd-all 內部啟動 plugin-tools `plugin-update` 時在命令列前綴）。Bash tool 的 fresh-shell 特性使它無法跨 tool call 存活——僅限單一命令列生命週期。
+
+## 三方責任
+
+| 角色 | 責任 | 載體 |
+|------|------|------|
+| **Setter** | `INTERACTION=unattended` 解析成立時 `mark_unattended`；對 subprocess 呼叫在命令列前綴 env var | `idd-all` Phase 0.5（chain 模式由 `idd-all-chain` Phase 0 代行）|
+| **Detector** | 一律經 `scripts/lib/unattended-state.sh` 的 `is_unattended <repo_root>`（env var 先、file 次、TTL 防呆內建）；不得自行 grep 檔案或檢查 TTY | `idd-clarify` Step 4.8.A、`idd-issue` Stage 4.5、IC_R011 checkpoint、（跨 plugin）plugin-tools Phase 0.5 讀 env var 即可 |
+| **Cleanup** | Phase 6 terminal report 前 + **每一條 abort path** `clear_unattended` | `idd-all` / `idd-all-chain` |
+
+## Helper API（`scripts/lib/unattended-state.sh`）
+
+```bash
+. "$CLAUDE_PLUGIN_ROOT/scripts/lib/unattended-state.sh"
+mark_unattended "$CWD" "idd-all"    # setter
+is_unattended "$CWD" && echo un     # detector（exit 0 = unattended）
+clear_unattended "$CWD"             # cleanup
+```
+
+測試：`scripts/tests/unattended-state/test.sh`（9 斷言：mark/clear/env-compat/stale-TTL/corrupt）。
+
+## Cross-plugin 對接（plugin-tools #60 detector）
+
+plugin-tools 的 `plugin-update` Phase 0.5 讀 **env var**——idd-all 呼叫它時以 `IDD_ALL_UNATTENDED=1 <cmd>` 前綴滿足（本契約第 2 訊號）。plugin-tools 側文件 cross-reference 的更新屬 psychquant-claude-plugins repo（#123 Residue）。

--- a/plugins/issue-driven-dev/scripts/lib/unattended-state.sh
+++ b/plugins/issue-driven-dev/scripts/lib/unattended-state.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# unattended-state.sh — the reliable in-harness unattended signal (#123).
+#
+# WHY A STATE FILE: Claude Code's Bash tool spawns a fresh shell per call, so
+# "idd-all exports IDD_ALL_UNATTENDED=1 for its sub-skills" cannot work as a
+# literal env var hand-off. And a TTY heuristic ([ ! -t 0 ]) is ALWAYS true
+# inside the harness (#222) — useless as an attended/unattended discriminator.
+# The orchestrator therefore marks unattended mode in a state file; detectors
+# consult it (plus the env var, kept as a compat layer for real subprocesses
+# like plugin-tools' plugin-update, which idd-all launches with the variable
+# prefixed on the command line).
+#
+# Contract (references/unattended-contract.md is the normative doc):
+#   mark_unattended <repo_root> <by>     write the flag (idd-all Phase 0.5)
+#   clear_unattended <repo_root>         remove it (Phase 6 + all abort paths)
+#   is_unattended <repo_root>            exit 0 iff active AND fresh (<24h)
+#                                        stale file → exit 1 + warning + auto-clear
+STATE_REL=".claude/.idd/state/unattended.json"
+
+mark_unattended() { # repo_root by
+  local root="$1" by="${2:-idd-all}"
+  mkdir -p "$root/.claude/.idd/state"
+  printf '{"active":true,"by":"%s","started_at":"%s"}\n' \
+    "$by" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$root/$STATE_REL"
+}
+
+clear_unattended() { # repo_root
+  rm -f "$1/$STATE_REL"
+}
+
+is_unattended() { # repo_root
+  local root="$1" f="$1/$STATE_REL"
+  # env var wins immediately (compat layer — real subprocess hand-off)
+  [ "${IDD_ALL_UNATTENDED:-}" = "1" ] && return 0
+  [ -f "$f" ] || return 1
+  # TTL guard: a crashed orchestrator must not leave attended sessions
+  # permanently mis-detected. started_at older than 24h = stale → warn + clear.
+  local started now age
+  started=$(python3 -c '
+import json,sys,datetime
+try:
+    d=json.load(open(sys.argv[1]))
+    t=datetime.datetime.strptime(d["started_at"], "%Y-%m-%dT%H:%M:%SZ")
+    print(int(t.replace(tzinfo=datetime.timezone.utc).timestamp()))
+except Exception:
+    print(0)
+' "$f" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  age=$(( now - started ))
+  if [ "$started" -eq 0 ] || [ "$age" -gt 86400 ]; then
+    echo "⚠ stale/corrupt unattended flag ($f, age ${age}s) — clearing; treating session as ATTENDED." >&2
+    rm -f "$f"
+    return 1
+  fi
+  return 0
+}

--- a/plugins/issue-driven-dev/scripts/tests/unattended-state/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/unattended-state/test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# test.sh — unattended-state helper contract (#123/#222)
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert-helpers.sh"
+. "$HERE/../../lib/unattended-state.sh"
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+
+# default: attended
+( unset IDD_ALL_UNATTENDED; is_unattended "$W" ); refute "clean root → attended" test $? -eq 0
+
+# mark → active
+mark_unattended "$W" "idd-all"
+( unset IDD_ALL_UNATTENDED; is_unattended "$W" ); require "marked → unattended" test $? -eq 0
+assert_grep "flag records writer" '"by":"idd-all"' "$(cat "$W/.claude/.idd/state/unattended.json")"
+
+# clear → attended
+clear_unattended "$W"
+( unset IDD_ALL_UNATTENDED; is_unattended "$W" ); refute "cleared → attended" test $? -eq 0
+
+# env var compat layer wins without file
+( export IDD_ALL_UNATTENDED=1; is_unattended "$W" ); require "env var compat layer → unattended" test $? -eq 0
+
+# stale (>24h) → warn + auto-clear + attended
+mkdir -p "$W/.claude/.idd/state"
+printf '{"active":true,"by":"idd-all","started_at":"2020-01-01T00:00:00Z"}\n' > "$W/.claude/.idd/state/unattended.json"
+( unset IDD_ALL_UNATTENDED; is_unattended "$W" 2>"$W/stale-err" ); refute "stale flag → attended" test $? -eq 0
+assert_grep "stale warning surfaced" "stale" "$(cat "$W/stale-err")"
+assert_file_absent "stale flag auto-cleared" "$W/.claude/.idd/state/unattended.json"
+
+# corrupt json → treated stale
+printf 'not-json' > "$W/.claude/.idd/state/unattended.json" 2>/dev/null || true
+mkdir -p "$W/.claude/.idd/state"; printf 'not-json' > "$W/.claude/.idd/state/unattended.json"
+( unset IDD_ALL_UNATTENDED; is_unattended "$W" 2>/dev/null ); refute "corrupt flag → attended" test $? -eq 0
+
+print_summary "unattended-state"

--- a/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all-chain/SKILL.md
@@ -93,6 +93,9 @@ TaskCreate(name="report_and_stop", description="Phase 4: 印 forest tree printou
 
 ### Phase 0: Pre-flight + cluster branch setup
 
+> **Unattended signal + 依賴 gate（v2.92+ #123/#211）**：chain 模式 = `(direct-commit, unattended)`，chain shell 在建 cluster branch 前先：(1) `. "$CLAUDE_PLUGIN_ROOT/scripts/lib/unattended-state.sh" && mark_unattended "$CWD" "idd-all-chain"`（契約見 `references/unattended-contract.md`；Phase 4 report 後與所有 abort path `clear_unattended`）；(2) superpowers hard gate（`check-plugin-presence.sh claude-plugins-official superpowers || abort`）+ spectra warn（同 idd-all Step 0.35 — 缺席時 unattended chain 中途 abort 留孤兒的正是本 gate 防的）。
+
+
 #### Step 0.1: Argument Parsing
 
 Same as `/idd-all`,plus:

--- a/plugins/issue-driven-dev/skills/idd-all/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-all/SKILL.md
@@ -202,6 +202,23 @@ gh auth status > /dev/null 2>&1 || abort "gh CLI not authenticated. Run: gh auth
 
 > **Mode-specific gates(working tree clean、on default branch)移到 Phase 0.5**:那些 gate 只在 PR mode 必須,direct-commit mode 預設留在 user 當前 branch + 容許未 commit 變更(由 user 自負其責)。
 
+#### Step 0.35: Dependency early gates（v2.92+ #211；scope 含 spectra per #210 audit）
+
+Phase 1 之前先驗 delegation 依賴，避免 unattended chain 中途 abort 留孤兒 issue/branch：
+
+```bash
+# superpowers — 無條件 hard gate（diagnose/implement 的 delegation 必經）
+"$CLAUDE_PLUGIN_ROOT/scripts/check-plugin-presence.sh" \
+  claude-plugins-official superpowers || abort "superpowers missing — install first (see hint above), then re-run /idd-all"
+
+# spectra — Phase 0 只 warn（complexity 尚未判定，SDD path 不一定觸發）；
+# Phase 3b 入口另有 hard gate（見該段）— fail 發生在任何 spectra artifact 產生之前
+if ! command -v spectra >/dev/null 2>&1; then
+  echo "⚠ spectra CLI not on PATH — if diagnosis routes to Spectra tier, Phase 3b will abort."
+  echo "  Pre-empt: install the Spectra plugin/CLI before long unattended runs."
+fi
+```
+
 #### Step 0.4: Resolve Issue Number
 
 - **from-issue mode**(`/idd-all #19`): 確認 issue #19 存在且 OPEN(`gh issue view 19 -R "$GITHUB_REPO" --json state -q .state`); 若 state=CLOSED → abort
@@ -316,7 +333,19 @@ Based on the user's selection, set:
 ```bash
 # Resolved-tuple notice (mandatory — print before any state-mutating action)
 echo "→ Path: ${PATH_AXIS} (${INTERACTION}) — ${REASON}"
+
+# Unattended signal (#123 — normative contract: references/unattended-contract.md)
+# State file 是 harness 內唯一跨 tool-call 可靠訊號（env var 不跨 fresh shell、
+# TTY 恆非互動 #222）。attended 分支的 clear 是防呆：清掉 crashed prior run 的殘留。
+. "$CLAUDE_PLUGIN_ROOT/scripts/lib/unattended-state.sh"
+if [ "$INTERACTION" = "unattended" ]; then
+  mark_unattended "$CWD" "idd-all"
+else
+  clear_unattended "$CWD"
+fi
 ```
+
+> **Subprocess hand-off（#123 契約訊號 2）**：unattended 模式下，idd-all 內部啟動的**真 subprocess**（如 plugin-tools `plugin-update`）必須在命令列前綴 `IDD_ALL_UNATTENDED=1`（state file 只對經 `is_unattended` 的 detector 有效；外部 plugin 讀 env var）。
 
 **PR mode branch setup**(只在 `PATH_AXIS=PR` 執行):
 
@@ -564,6 +593,14 @@ idd-all 走 SDD path 時,**必須**串完三步:`spectra-discuss` → `spectra-p
 > - `INTERACTION=attended` → **完全不傳** unattended hint。`spectra-discuss` 多輪節奏、`spectra-propose` Step 10 Park/Apply 問題、`spectra-apply` Step 4 continue-confirmation 都 native fire,user 在 keyboard 自然回應
 >
 > idd-all 不修改 spectra 任何檔案 — 全程用 args 傳指示(或不傳)override sub-skill 的 attended 預設。
+
+#### Step 3b.0: Spectra presence hard gate（#211/#210）
+
+```bash
+command -v spectra >/dev/null 2>&1 || abort "Spectra tier routed but spectra CLI is missing.
+   Install the Spectra plugin, then re-run /idd-all #$N — aborting BEFORE any
+   spectra artifact is created (no half-baked openspec/changes/ residue)."
+```
 
 #### Step 3b.1: Capture issue context for prompt
 
@@ -882,6 +919,8 @@ With `--review` (`REVIEW_FLAG="--review"`):
 Next: review last ${COMMIT_COUNT} commits (git log -${COMMIT_COUNT}), then run /idd-close #${N}
 ```
 
+**Cleanup（#123）**：terminal report 印出後 `clear_unattended "$CWD"` — unattended flag 的生命週期 = 本次 orchestration。
+
 **STOP**。不 auto-merge(PR mode)、不 auto-close(both modes)。Per MANIFESTO doctrine,verify-gated PASS 是 terminal default disposition;auto-merge mechanic 屬 **#37** bulk-solve autopilot 範疇,**不**是 idd-all default。`--review` 是 **orchestrator-scope messaging-only** opt-in,不會讓 idd-all 等候 — 它只表態 "user 還想自己再過一次" 並切換 Phase 6 wording。(per #108 DA3: orchestrator-scope qualifier matters — humans/CI downstream may react to the changed text differently, so the flag is messaging-only **at orchestrator scope**, not necessarily end-to-end.)
 
 #### Phase 6 Action items surface (v2.74.0+, #137)
@@ -942,6 +981,7 @@ fi
 | `gh pr create` fail | Phase 5 abort,branch 已 push,提示手動開 PR |
 
 abort 時:
+- `clear_unattended "$CWD"`（#123 — 絕不留 stale unattended flag 誤導下一個 attended session）
 - TaskList 標記當前 phase 為 in_progress(不要 mark completed)
 - 顯示「自己手動接手」的具體命令(例:`/idd-verify #19` 或 `gh pr create ...`)
 - branch 不刪除(保留進度,user 可繼續)

--- a/plugins/issue-driven-dev/skills/idd-clarify/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-clarify/SKILL.md
@@ -162,11 +162,14 @@ fi
 
 Step 5a (scan mode) 開始前,偵測 unattended mode。 若 unattended → 寫的 surfaced rows 全部用 `deferred` status + cite-registered reason literal,而非 `surfaced`。 Step 0.5 gate 對 reason-matched `deferred` rows proceed-with-warn,unattended chain 不再 silent break。
 
-**Detection (reuse `idd-issue` Stage 4.5 既有 pattern, single-site convention)**:
+**Detection（#123/#222 — 經 unattended-contract 統一，TTY heuristic 移除）**:
 
 ```bash
+# TTY check 在 harness 內恆真（#222）— 不得用。唯一可靠訊號 = state file + env var
+# （contract 見 references/unattended-contract.md）。
+. "$CLAUDE_PLUGIN_ROOT/scripts/lib/unattended-state.sh"
 IS_UNATTENDED="false"
-if [ ! -t 0 ] || [ -n "${IDD_ALL_UNATTENDED:-}" ]; then
+if is_unattended "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"; then
   IS_UNATTENDED="true"
 fi
 ```

--- a/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-issue/SKILL.md
@@ -1388,13 +1388,15 @@ Recovery workflow:
 
 ```bash
 # Add at top of Stage 4.5 gate (before AskUserQuestion):
-if [ -z "${JSONL_GITIGNORE_DECISION:-}" ] && [ ! -t 0 ] && [ -n "${IDD_ALL_UNATTENDED:-}${CI:-}" ]; then
-  # No TTY AND we're in /idd-all unattended chain OR a CI environment.
+. "$CLAUDE_PLUGIN_ROOT/scripts/lib/unattended-state.sh"
+if [ -z "${JSONL_GITIGNORE_DECISION:-}" ] && { is_unattended "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || [ -n "${CI:-}" ]; }; then
+  # /idd-all unattended chain（state file / env var per references/unattended-contract.md）
+  # OR a CI environment. TTY check removed (#222 — always false in harness).
   # Auto-select "skip-commit" as the safest default — jsonl writes locally
   # but isn't committed, no .gitignore change. Audit trail still produced
   # locally for whoever runs the unattended job.
   JSONL_GITIGNORE_DECISION="skip-commit"
-  echo "ℹ Stage 4.5 gate auto-defaulted to 'skip-commit' under unattended mode (no TTY + IDD_ALL_UNATTENDED/CI)." >&2
+  echo "ℹ Stage 4.5 gate auto-defaulted to 'skip-commit' under unattended mode (unattended-contract signal / CI)." >&2
 fi
 ```
 


### PR DESCRIPTION
Refs #123
Refs #222
Refs #211

## Summary
idd-all unattended 基礎設施 cluster（same-file bundle）：

- **#123** unattended-contract：state file `.claude/.idd/state/unattended.json`（TTL 24h + corrupt 防呆）為 primary 訊號、env var 為 subprocess compat layer；idd-all Phase 0.5 setter + Phase 6/abort cleanup + chain 代行；normative doc `references/unattended-contract.md`；helper `lib/unattended-state.sh` + 9 斷言測試
- **#222** TTY 偵測恆真修復：harness Bash 永無 TTY，idd-clarify/idd-issue 的 `[ ! -t 0 ]` 偵測（attended session 也被 auto-defer）廢除，統一走 `is_unattended`
- **#211** 依賴 early gates（scope 含 spectra per #210 audit）：Phase 0.35 superpowers hard gate + spectra warn；Phase 3b.0 spectra hard gate（fail 於任何 artifact 產生前，不留孤兒）；idd-all-chain 同步

## Verification
Contract 測試 9/9 + 接線 grep 全查。詳見 #123 的 cluster Verify comment。

## Checklist
- [x] Diagnose ×3 / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize these issues

---
🤖 Generated by /idd-all cluster mode. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
