### PR TITLE
feat: Step 6.5 monorepo host plugin disambiguation (candidates + specificity)

### DIFF
--- a/plugins/issue-driven-dev/references/distribution-detection.md
+++ b/plugins/issue-driven-dev/references/distribution-detection.md
@@ -176,7 +176,7 @@ resolve_plugin_name() {
 }
 ```
 
-**Monorepo host case**: when `repo_root` is the marketplace host itself (e.g. `psychquant-claude-plugins` containing 37 plugins), `resolve_plugin_name` returns the FIRST plugin whose source path starts within `repo_root`. This is ambiguous for monorepo hosts — caller (Step 6.5) should handle this case explicitly, e.g. by prompting user "which plugin?" via AskUserQuestion. v1 simplification: assume single-plugin per repo (true for most non-host cases); document monorepo handling as a v2 enhancement.
+**Monorepo host case（v2, #68）**: `scripts/lib/resolve-plugin-candidates.sh` 的 `resolve_plugin_candidates <repo_root> [<cwd>]` 回**全部**匹配 plugin，依 cwd specificity 排序（plugin dir 是 cwd 祖先者最前、越深越前；path-boundary 安全 — `beta-extra` 不被 `beta` 前綴誤吃）。Caller（Step 6.5）契約：0 → silent skip（非 plugin close）；1 → proceed；N>1 attended → AskUserQuestion（top-3 + Other）；N>1 unattended → 取最 specific 候選 + audit note（non-blocking）。`resolve_plugin_name` 保留為 v1 相容 wrapper（首候選）。測試：`scripts/tests/resolve-plugin-candidates/`。
 
 ### `infer_distribution_type(repo_root, github_repo) -> string`
 

--- a/plugins/issue-driven-dev/scripts/lib/resolve-plugin-candidates.sh
+++ b/plugins/issue-driven-dev/scripts/lib/resolve-plugin-candidates.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# resolve-plugin-candidates.sh — marketplace plugin resolution with monorepo
+# host disambiguation (#68; supersedes the v1 "first match" simplification in
+# references/distribution-detection.md).
+#
+#   resolve_plugin_candidates <repo_root> [<cwd>]
+#     stdout: ALL plugin names whose marketplace source resolves inside
+#             repo_root — ordered by specificity to <cwd> (default $PWD):
+#             plugins whose dir is an ancestor of cwd first (deepest first),
+#             then the rest in manifest order.
+#   resolve_plugin_name <repo_root>
+#     backward-compat wrapper: first candidate only (v1 contract).
+#
+# Caller contract (idd-close Step 6.5):
+#   0 candidates → silent skip (not a plugin close)
+#   1 candidate  → proceed
+#   N>1 attended → AskUserQuestion: top-3 + Other
+#   N>1 unattended → take the top (most-specific) candidate + audit note
+resolve_plugin_candidates() {
+  local repo_root="$1" cwd="${2:-$PWD}"
+  local resolved_root current manifest manifest_dir
+  resolved_root=$(cd "$repo_root" 2>/dev/null && pwd -P) || resolved_root="$repo_root"
+  cwd=$(cd "$cwd" 2>/dev/null && pwd -P) || cwd="$cwd"
+  current="$resolved_root"
+  while :; do
+    manifest="$current/.claude-plugin/marketplace.json"
+    if [ -f "$manifest" ]; then
+      manifest_dir=$(cd "$(dirname "$manifest")/.." 2>/dev/null && pwd -P) || \
+        manifest_dir=$(dirname "$(dirname "$manifest")")
+      # emit "specificity<TAB>seq<TAB>name": specificity = plugin dir path length
+      # when it is an ancestor of cwd (deeper = more specific), else 0.
+      local seq=0
+      jq -r '.plugins[]? | select(.source | type == "string") | "\(.name)\t\(.source)"' \
+        "$manifest" 2>/dev/null \
+        | while IFS=$'\t' read -r pname psrc; do
+            [ -z "$pname" ] && continue
+            seq=$((seq + 1))
+            local plugin_dir spec=0
+            plugin_dir=$(cd "$manifest_dir/$psrc" 2>/dev/null && pwd -P) || continue
+            case "$plugin_dir/" in
+              "$resolved_root/"|"$resolved_root/"*) : ;;
+              *) continue ;;
+            esac
+            case "$cwd/" in
+              "$plugin_dir/"|"$plugin_dir/"*) spec=${#plugin_dir} ;;
+            esac
+            printf '%08d\t%08d\t%s\n' "$spec" "$seq" "$pname"
+          done \
+        | sort -t$'\t' -k1,1nr -k2,2n \
+        | cut -f3
+      return 0
+    fi
+    [ "$current" = "$HOME" ] && break
+    [ "$current" = "/" ] && break
+    current=$(dirname "$current")
+  done
+  return 0
+}
+
+resolve_plugin_name() { # v1 backward-compat: first candidate
+  resolve_plugin_candidates "$1" | head -1
+}

--- a/plugins/issue-driven-dev/scripts/tests/resolve-plugin-candidates/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/resolve-plugin-candidates/test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# test.sh — monorepo host plugin disambiguation (#68)
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert-helpers.sh"
+. "$HERE/../../lib/resolve-plugin-candidates.sh"
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+
+# fixture: marketplace host with 3 plugins
+mkdir -p "$W/host/.claude-plugin" "$W/host/plugins/alpha" "$W/host/plugins/beta" "$W/host/plugins/beta-extra"
+cat > "$W/host/.claude-plugin/marketplace.json" <<'JSON'
+{"plugins":[
+  {"name":"alpha","source":"./plugins/alpha"},
+  {"name":"beta","source":"./plugins/beta"},
+  {"name":"beta-extra","source":"./plugins/beta-extra"}
+]}
+JSON
+
+# 1. host root cwd → all 3, manifest order（無 specificity 信號）
+OUT=$(resolve_plugin_candidates "$W/host" "$W/host")
+assert_eq "host cwd → 3 candidates manifest order" "alpha
+beta
+beta-extra" "$OUT"
+
+# 2. cwd inside beta → beta first
+OUT=$(resolve_plugin_candidates "$W/host" "$W/host/plugins/beta")
+assert_eq "beta cwd → beta 排最前" "beta" "$(echo "$OUT" | head -1)"
+
+# 3. beta-extra cwd 不被 beta 前綴誤吃（path-boundary 正確）
+OUT=$(resolve_plugin_candidates "$W/host" "$W/host/plugins/beta-extra")
+assert_eq "beta-extra cwd → beta-extra 排最前" "beta-extra" "$(echo "$OUT" | head -1)"
+
+# 4. 單一 plugin repo（非 host）→ 唯一候選
+mkdir -p "$W/solo/.claude-plugin" "$W/solo/p"
+printf '{"plugins":[{"name":"solo-p","source":"./p"}]}' > "$W/solo/.claude-plugin/marketplace.json"
+OUT=$(resolve_plugin_candidates "$W/solo")
+assert_eq "solo repo → 1 candidate" "solo-p" "$OUT"
+
+# 5. 無 marketplace → 空（silent skip 語意）
+mkdir -p "$W/plain"
+OUT=$(resolve_plugin_candidates "$W/plain")
+assert_eq "非 marketplace repo → empty" "" "$OUT"
+
+# 6. v1 wrapper 相容
+assert_eq "resolve_plugin_name = 首候選" "alpha" "$(cd "$W/host" && resolve_plugin_name "$W/host")"
+
+print_summary "resolve-plugin-candidates"

--- a/plugins/issue-driven-dev/skills/idd-close/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-close/SKILL.md
@@ -658,6 +658,8 @@ Skill(skill="issue-driven-dev:idd-update", args="#NNN")
 
 ### Step 6.5: Distribution Sync chain (v2.56.0+, #45)
 
+> **Monorepo host 消歧（v2.92+, #68）**：`resolve_plugin_name` 在 marketplace host（一 repo 多 plugin）下有歧義 — 改用 `. "$CLAUDE_PLUGIN_ROOT/scripts/lib/resolve-plugin-candidates.sh"` 的 `resolve_plugin_candidates "$CWD" "$PWD"`：0 候選 → silent skip；1 → proceed；N>1 → attended 用 AskUserQuestion（top-3 依 cwd specificity + Other）、unattended 取首位 + audit note。
+
 **Compliance**: this step implements close-tier distribution-sync checkpoint per IC_R011-style 3-option AskUserQuestion + audit trail pattern (canonical reference: [`references/ic-r011-checkpoint.md`](../../references/ic-r011-checkpoint.md)). Complements `che-claude-config/rules/common-release-flow.md` (release-tier trigger).
 
 **Why this step**: for plugin/MCP/CLI repos, fix lands in main but user-facing distribution channel (marketplace.json / binary release) needs separate sync. Without Step 6.5 mechanical checkpoint, "marketplace.json sync" relies on user memory → 「修了卻沒修」 anti-pattern (e.g. `che-apple-mail-mcp#72` PR #75 merged but marketplace.json not bumped → users `/plugin update` got old binary).


### PR DESCRIPTION
Refs #68

## Summary
Step 6.5 monorepo host 消歧：`resolve_plugin_candidates` 全候選 + cwd-specificity 排序 + caller 契約（0/1/N 分派，unattended 首位+audit）。v1 wrapper 相容。6 斷言 + red-proof。

注意：與 PR #239 同檔不同 section（idd-close SKILL.md），git 自動合併可期。

## Checklist
- [x] Diagnose / Implement / Verify ✓
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize this issue

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer** (Closes/Fixes/Resolves).
