### PR TITLE
fix: GNU-first stat in file_mtime() to unbreak GNU/Linux CI (#245)

### DIFF
--- a/plugins/issue-driven-dev/scripts/idd-tree-lock.sh
+++ b/plugins/issue-driven-dev/scripts/idd-tree-lock.sh
@@ -62,7 +62,12 @@ LOCK="$LOCK_PARENT/tree-lock"
 
 now_epoch()  { date +%s; }
 now_iso()    { date -u +%Y-%m-%dT%H:%M:%SZ; }
-file_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+# GNU-first: `stat -c %Y` is GNU "format" (mtime); on Linux it succeeds and the
+# `||` short-circuits, so GNU's `-f`=--file-system multi-line output never leaks
+# into the mtime. On BSD/macOS `-c` is illegal → clean usage error to stderr, no
+# stdout (rc=1) → falls through to `-f %m` (BSD "format"). BSD-first breaks the
+# reverse way on Linux and reclaims fresh locks (#245). Regression: test.sh f11.
+file_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
 field()      { [ -f "$LOCK" ] && sed -n "s/^$1=//p" "$LOCK" | head -1; }
 valid_pid()  { printf '%s' "$1" | grep -qE '^[0-9]+$' && [ "$1" -gt 0 ] 2>/dev/null; }
 

--- a/plugins/issue-driven-dev/scripts/tests/idd-tree-lock/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/idd-tree-lock/test.sh
@@ -103,4 +103,31 @@ assert_eq "f10b exactly one holder after reclaim" "new" "$(lockpid_holder "$R")"
 require   "f10c no orphan reclaim mutex left"  bash -c "[ ! -d '$R/.claude/.idd/tree-lock.reclaim' ]"
 rm -rf "$R"
 
+# ── Fixture 11 (#245 REGRESSION): file_mtime() must resolve mtime under GNU stat
+#    semantics. `stat -f %m` is BSD "format"; on GNU/Linux `-f` = --file-system, so
+#    a BSD-first chain leaks a multi-line filesystem block into holder_is_live()'s
+#    freshness arithmetic — a FRESH empty lock is then wrongly reclaimed (f8 passes
+#    on macOS, fails on the Linux CI runner). We shim a GNU-semantics `stat` onto
+#    PATH so the Linux-only failure reproduces on ANY host: RED while file_mtime
+#    tries `-f` first, GREEN once it tries `-c %Y` first. ──
+R="$(mk_repo)"; mkdir -p "$R/.claude/.idd"
+: > "$R/.claude/.idd/tree-lock"                   # empty + fresh = mid-acquire window (as f8)
+SHIMDIR="$(mktemp -d)"
+cat > "$SHIMDIR/stat" <<'SHIM'
+#!/bin/sh
+# GNU-coreutils `stat` semantics, for the #245 regression only:
+#   -f  → --file-system (NOT BSD's "format"); handed a bogus %m operand it prints a
+#         multi-line fs block for the real file and exits nonzero.
+#   -c  → format string ($2=%Y = mtime); prints a bare epoch integer, exit 0.
+case "$1" in
+  -f) printf 'File: "%s"\nID: 0 Namelen: 255 Type: apfs\nBlock size: 4096\n' "${3:-$2}"; exit 1 ;;
+  -c) date +%s; exit 0 ;;
+  *)  exit 1 ;;
+esac
+SHIM
+chmod +x "$SHIMDIR/stat"
+( export PATH="$SHIMDIR:$PATH"; bash "$HELPER" acquire --repo "$R" --id A --pid "$$" ) >/dev/null 2>&1
+assert_exit "f11 GNU-stat shim: fresh empty lock still held (BSD-first file_mtime regression #245)" 3 $?
+rm -rf "$R" "$SHIMDIR"
+
 print_summary


### PR DESCRIPTION
## Problem

CI is **red on `main`**: the `idd-tree-lock` fixture suite fails on the GNU/Linux
runner (green on macOS) —

```
✗ f8 fresh unreadable lock -> held (not stolen): expected exit 3 got 1
```

A red `main` obscures the CI signal for every future PR, so this is the
highest-priority fix in the backlog.

## Root cause — BSD-first `stat` breaks on GNU/Linux

`scripts/idd-tree-lock.sh` `file_mtime()` tried BSD syntax first:

```bash
file_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
```

The two `stat` dialects read the flags incompatibly:

| flag | BSD / macOS | GNU / coreutils (Linux CI) |
|------|-------------|----------------------------|
| `-f` | *format* string (`%m` = mtime) | `--file-system` (prints multi-line fs status) |
| `-c` | illegal option → clean usage error, no stdout | *format* string (`%Y` = mtime) |

On Linux, `stat -f %m "$LOCK"` is parsed as `--file-system` and prints the
lock's multi-line filesystem block to stdout. `file_mtime()` therefore returns
`"<multi-line fs garbage>\n<real mtime>"`, which corrupts `holder_is_live()`'s
freshness arithmetic (`age=$(( now - mtime ))` on a multi-line string fails →
holder judged "not live" → a **fresh** empty lock is wrongly reclaimed instead
of held). Hence `expected exit 3 got 1`.

## Fix

Try **GNU-first**, which resolves cleanly on both platforms:

```bash
file_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
```

- **GNU/Linux**: `stat -c %Y` succeeds → bare integer, `||` short-circuits (no fs garbage ever produced).
- **BSD/macOS**: `stat -c %Y` fails cleanly (illegal option, no stdout — verified `rc=1`, empty stdout) → `||` falls through to `stat -f %m` → correct mtime.

## Test — RED/GREEN regression

New fixture **f11** PATH-shims a GNU-semantics `stat` so the Linux-only failure
reproduces on **any** host: RED with the BSD-first order (reproduces the exact
`expected exit 3 got 1` symptom on macOS), GREEN after the swap.

- Before fix: `idd-tree-lock` 20 PASS / 1 FAIL (f11).
- After fix: `idd-tree-lock` **21 PASS / 0 FAIL**.
- Full CI entrypoint (`run-all-tests.sh`): **21 suites, 0 failed**.

## Verification

- [x] `bash plugins/issue-driven-dev/scripts/run-all-tests.sh` → 21 suites, 0 failed (local macOS)
- [ ] CI Linux runner green on this branch ← the cross-platform check I can't run locally

Refs #245
