### PR TITLE
docs: complete the sanctioned path catalog to v2.96 reality

### DIFF
--- a/docs/skill-dimensions.md
+++ b/docs/skill-dimensions.md
@@ -2,7 +2,7 @@
 
 > **Purpose**:把「設計向度」(design dimensions)明確化,讓 IDD plugin 維護者 + contributor 在加新 skill / 修舊 skill 時,**explicitly 對齊每個 dimension 的設計選擇**,而非 implicit drift。
 
-> **狀態**:initial skeleton(由 AI agent 從既有 design corpus distill,user 補充未列向度)。Maintained 維護紀律見 § Provenance。
+> **狀態**:maintained（#122 補完 2026-07-17 — skeleton → 對齊 v2.96 現實）。Maintained 維護紀律見 § Provenance。
 
 ---
 
@@ -206,7 +206,8 @@ IDD plugin 已累積 14+ skills(`idd-issue` / `idd-diagnose` / `idd-implement` /
 
 下列 dimensions 是 AI agent 從 corpus distill 不出,但 user 可能已有的:
 
-- **D12**: ? (cost / token / time 維度?)
+- **D12**: **Surfacing vs Lifecycle**（#140 認領中 — surfacing-only primitive family：idd-list / idd-clarify / idd-find；待 idd-find 落地後由 #140 正式定義）
+- **D12-alt**: ? (cost / token / time 維度?)
 - **D13**: ? (cross-repo / cross-skill 整合?)
 - **D14**: ? (retroactive vs forward-looking?)
 - **D15**: ? (formal vs informal / spec-bound vs ad-hoc?)
@@ -233,12 +234,13 @@ IDD plugin 已累積 14+ skills(`idd-issue` / `idd-diagnose` / `idd-implement` /
 | `idd-comment` | Sep | Atom | Side | W | Fwd | S / Batch | SHOULD template | Unatt-capable | Sk + flags | Cl-non |
 | `idd-edit` | Sep | Atom | Side | W | (任) | S / Batch | SHALL preview before write | Att-only | Sk | Cl-non |
 | `idd-list` | (n/a) | Atom | n/a | R | (查) | S | n/a | Unatt-capable | Sk + flags | Cl-non |
+| `idd-clarify` | Sep | Atom | Delib(surface-only) | W (annotation block) | Fwd | S | SHALL hard-gate consumer (diagnose Step 0.5) | Unatt (deferred-row 機制 #137) | Sk + flags | Cl-non |
 | `idd-report` | Sep | Atom | Side | W | Bwd | S | SHALL aggregate | Att | Sk | Cl-non |
 | `idd-route` | (n/a) | Atom | n/a | R (recommend) / W (record) | (查) | S | n/a | Unatt-capable | Sk | Cl-non |
-| `idd-all` | **Auto (Hyb degraded)** ⚠ | Orch | (跨 D / E / Side) | W | (跨) | S / Cluster | mostly SHALL but soft Phase 0.4 | Hyb | Sk + flags | Cl-non |
+| `idd-all` | **Auto (Hyb degraded)** ⚠ | Orch | (跨 D / E / Side) | W | (跨) | S / Batch (v2.83 conflict-class ordered) / Cluster | mostly SHALL but soft Phase 0.4 | Hyb | Sk + flags | Cl-non |
 | `idd-all-chain` | **Auto × N (Hyb degraded)** ⚠ | Orch | (跨) | W | (跨) | Ch (1 root + N spawn) | mostly SHALL but soft Phase 0.4 | Hyb | Sk + flags | Cl-non |
 
-⚠ = D1 design tension(per #122)— 預設過 aggressive,proposal 改為 Sup(Supervised Automation)。
+⚠ = D1 design tension（#122 原 framing）— 已由 path-catalog 裁決取代：不強制 Sup，改為本 catalog 把各 path 的 risk 顯式列出、discipline 在 user 選 path 時 explicit（見 workflows.md Anti-patterns + #120 的 Layer V deferred-record 機制）。
 
 ---
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -84,6 +84,14 @@ idd-issue → idd-diagnose → spectra-propose → spectra-apply → idd-verify 
 
 ---
 
+#### P-meeting — meeting-type deliberation（#57，v2.93+）
+
+`idd-issue --type meeting` → `idd-diagnose`（type=meeting 最優先分流：Phase A/B/C 審議 Strategy，**不進** Layer 1 / Layer V / Spectra / 硬閘 / Layer P，無 complexity verdict）→ `idd-plan`（meeting-adapted Plan body：議程 → 決策點 → 行動項；**不 chain** idd-implement）→ 會議本體（user-driven）→ `idd-close`（meeting-specific gate：最新 Meeting Plan Phase C → fallback diagnose Strategy Phase C，行動項逐條 disposition；decision→action mapping，無 /idd-verify）。
+
+- **Use case**：審議/決策工作 — deliverable 是決策與 follow-up，不是 code
+- **Touchpoints**：4（issue → 審議 plan approve → 會議 → close disposition）
+- **Risk**：low — 全程 attended by nature
+
 ### B. Convenience-orchestrator paths(快速 lifecycle 完成)
 
 #### P-auto-from-diagnosed — diagnose 已過,跑自動化
@@ -114,6 +122,14 @@ idd-issue → idd-all #N
 - **Risks**:**中-高** — deliberation moment 被 swallow;若 issue body 模糊,AI auto-proceed 可能 mis-route
 - **適用情境**:`/loop` autonomous mode / quick housekeeping P3 issues
 - **Cross-link**:#122 提案改 Supervised Automation
+
+#### P-batch-drain — multi-issue conflict-class-ordered sequential（v2.83+，#182）
+
+`idd-all #a #b #c`（≥2 distinct #N）= 對 backlog 做 **sequential** drain，外圈按各 issue Diagnosis 的 `### Conflict Class` 排序（E/D 先、B/C 同資源相鄰、A 順序不拘）。**誠實邊界：不是並發** — taxonomy 是「手動跨 session / 未來 primitive」的並行安全契約。
+
+- **Use case**：積壓清倉（本 repo 2026-07 focused drain 即此 path 實例）
+- **Touchpoints**：2 + 決策檢查點（decision-heavy issue 停在 diagnosed 等拍板）
+- **Risk**：middle — unattended 段沿用 P-auto 系列 risk；排序保證同資源不交錯
 
 #### P-cluster-pr — N issues 共 1 PR
 
@@ -324,6 +340,21 @@ idd-edit comment:NNN --append --body "..."
 
 ---
 
+#### P-discussions-intake — Discussions 盲點橋接（#221，v2.95+）
+
+`idd-list --discussions`（opt-in surface：Q&A/Ideas ∧ 未答 ∧ 未被 issue 引用）→ **人判斷** → `idd-issue --from-discussion <url>`（Provenance verbatim seed + draft-and-confirm 回文）→ 進任一 single-issue lifecycle path。
+
+- **鐵律**：絕不 auto-file、絕不 auto-post 回文（unattended draft-only）
+- **Use case**：使用者回報以 GitHub Discussion 抵達（che-ical-mcp 105 事故的制度化解）
+- **Risk**：low — surfacing read-only；outward write 有 confirm gate
+
+#### P-clarify-audit — terminology / semantic surfacing（#135，v2.72+）
+
+`idd-clarify #N`（standalone，或被 idd-issue Step 4.6 delegate、被 idd-diagnose Step 0.5 gate 消費）→ `### Clarity Surface` annotation block（surfaced/resolved/dismissed rows）。Read-only surfacing primitive — 不 mutate lifecycle state，但其 surfaced rows 會 hard-block 後續 diagnose（gate 在 diagnose 端）。
+
+- **Use case**：issue body 用詞/語意精度審查；retroactive audit
+- **Risk**：low — 唯一副作用是 annotation block 寫入
+
 ### H. Unsupervised / autopilot paths(no human-in-loop)
 
 #### P-loop-autopilot
@@ -374,6 +405,7 @@ idd-edit comment:NNN --append --body "..."
 | `idd-comment` | | | | | | | ✓ batch | | | | ✓ standalone | |
 | `idd-edit` | | | | | | | ✓ batch | | | | ✓ standalone | |
 | `idd-list` | | | | | | | | | | | ✓ triage | ✓ cron |
+| `idd-clarify` | (issue 內 delegate) | | | | | | | | | | ✓ standalone audit | |
 | `idd-report` | | | | | | | | | | | ✓ aggregate | |
 | `idd-route` | | | | | | | | | | | ✓ recommend | |
 | `idd-all` | | | | ✓ all variants | ✓ cluster | | | | | | | ✓ loop |
@@ -386,7 +418,8 @@ idd-edit comment:NNN --append --body "..."
 ```
 Q1: 是 single issue 還是 multi issues?
 ├── Single
-│   └── Q2: 預期是 Simple / Plan / Spectra?
+│   └── Q1.5: type=meeting? ── Yes → P-meeting（複雜度評估前分流）
+│   └── Q2: 預期是 Simple / Plan / Spectra?（#129 硬閘：≥5 檔互依概念 / shared abstraction → MUST Plan，先於 Layer P）
 │       ├── Simple
 │       │   └── Q3: attended (你在 keyboard)?
 │       │       ├── Yes → P-atomic (5 touchpoints)
@@ -469,6 +502,9 @@ Q1: 是 single issue 還是 multi issues?
 ---
 
 ## Provenance
+
+> **2026-07-17（#122 補完）**：catalog 由 skeleton 補至 v2.96 現實 — 新增 P-meeting（#57）、P-batch-drain（#182）、P-discussions-intake（#221）、P-clarify-audit（#135）；decision tree 補 meeting 分流 + #129 硬閘；matrix 補 idd-clarify 列。後續新 path 隨 feature 落地就地 iterate（使用者裁決：本檔可就地補、不另開 issue）。
+
 
 - **首次版本**:2026-05-21 — AI agent skeleton,由 user 對 #122(原 marketplace#89,已 transfer 過來)提出 reframing(「不是強制,而是把所有可能 path 都列出來」)觸發
 - **觸發 insight**:user observation:強制單一 path 違反 user agency;path catalog 讓 discipline 在 user 選 path 時 explicit


### PR DESCRIPTION
Refs #122

## Summary
Path catalog 補完至 v2.96 現實（採用裁決：expose all sanctioned paths，不強制）：+4 新 path（P-meeting / P-batch-drain / P-discussions-intake / P-clarify-audit）、decision tree 補 meeting 分流 + #129 硬閘、兩份 matrix 補 idd-clarify、stale enforce-Sup footnote 換 catalog 裁決、skeleton banner 退役、D12 槽標記由 surfacing-family 案認領。純 docs/。

## Checklist
- [x] Diagnose（attended batch 2026-07-17, Simple）
- [x] Implement (1 commit, docs-only)
- [ ] Verify（docs-only — PR review 即驗）
- [x] **Verify-gated**: merge 後走 /idd-close ritual（number in Refs header；manual gate + closing summary; no auto-close trailer）
