### PR TITLE
feat: human-ux cluster — dashboard comment contract + idd-report rollup

### DIFF
--- a/plugins/issue-driven-dev/references/dashboard-comment.md
+++ b/plugins/issue-driven-dev/references/dashboard-comment.md
@@ -1,0 +1,53 @@
+# Dashboard Comment（#133, v2.97.0+）
+
+**一個 issue、一則 human-facing dashboard comment**：給 reviewer / collaborator 的敘事快照（現在在哪、卡在哪、你該做什麼），與 body `## Current Status`（結構化、給 AI / parser 讀）分工。本檔是格式與更新時點的 canonical 契約；4 個 lifecycle SKILL 的接線點與 `idd-report --rollup`（#134）都引用本檔，不內嵌複本。drift-guard：`scripts/tests/dashboard-comment/test.sh`。
+
+## 分工（為什麼不是 body 的一部分）
+
+| Surface | 讀者 | 性質 |
+|---------|------|------|
+| body `## Current Status` | AI / parser（idd-list、idd-update） | 結構化欄位（`**Phase**:` 等），機器可靠解析 |
+| dashboard comment | 人（reviewer / collaborator / 未來的自己） | **narrative for humans** — 一句話現況、blocker、行動呼籲；不要求機器可解析 |
+
+body 頂部（Current Status 區塊內）放一行 link 指向 dashboard comment（可發現性）；dashboard 不重複 body 的結構化欄位。
+
+## 格式模板
+
+comment **第一行必須是 marker**（機器定位用，更新時以 **marker 定位**做 comment surgery）：
+
+```markdown
+<!-- idd:dashboard -->
+## 📊 For Reviewer / Collaborator
+
+**現在**：<一句話 current state，人話，不是 phase 名>
+**Blocking**：<卡什麼 / 等誰；沒有就寫「無」>
+**你該做什麼**：<具體行動呼籲，例：review PR #N 的 X 段 / 無需動作，等 verify>
+
+_last-updated by <skill> at <phase transition>, <YYYY-MM-DD>_
+```
+
+- `<!-- idd:dashboard -->` 每個 issue 至多一則 comment 帶此 marker（found ≥ 2 → 取最早那則更新、警告）
+- `last-updated by` 是 provenance 欄：哪個 skill 在哪個 phase 轉換時更新的 — dashboard 過期時人一眼看出斷在哪站
+
+## 更新時點表（只綁 phase 轉換 — anti-fatigue 鐵律）
+
+**唯一合法的更新時點是 phase 轉換**（≤ 5 次 / issue 生命週期）。中間進度（commit、finding、討論）一律不觸發 — 那正是 #116 的 notification fatigue class：訂閱者每次 comment 更新都收通知，高頻更新會讓人 mute 整個 issue，dashboard 就死了。
+
+| Phase 轉換 | 負責 skill | Dashboard 更新內容 |
+|-----------|-----------|------------------|
+| → `diagnosed` | `idd-diagnose` | 現況 = root cause 一句話；你該做什麼 = 審 diagnosis / 等 implement |
+| → `implemented` | `idd-implement` | 現況 = 改了什麼一句話 + PR ref；你該做什麼 = review PR |
+| → `verified` / `needs-fix` | `idd-verify` | 現況 = verify verdict 一句話；你該做什麼 = merge（verified）/ 等修（needs-fix） |
+| → `closed` | `idd-close` | 現況 = 結案一句話（root cause + solution）；你該做什麼 = 無 |
+
+## 更新機制
+
+1. **首發**（issue 尚無 marker comment）：經 `gh-egress.sh comment` 發（走 mention / privacy net）
+2. **更新**：以 marker 定位既有 comment → `gh api PATCH /repos/:repo/issues/comments/:id` 整則替換（bounded-section-replace 語意 — dashboard 是快照不是 append log，舊快照不保留；歷史由 phase comments 本身承載）
+3. 找不到 marker comment 且 phase ≥ diagnosed → 視為首發補建（self-healing）
+
+## Scope 邊界
+
+- **不 pin**（GitHub API 不支援 comment pin）；可發現性靠 body 頂部 link + marker
+- **不推播**（無 @-mention 於 dashboard 內文 — 要 tag 人走 tagging-collaborators 協定，且只在行動呼籲真的指名時）
+- 聚合視圖（跨 issue 的 rollup）屬 `idd-report --rollup`（#134），本檔只管單 issue 快照

--- a/plugins/issue-driven-dev/scripts/tests/dashboard-comment/test.sh
+++ b/plugins/issue-driven-dev/scripts/tests/dashboard-comment/test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# test.sh — drift-guard for #133 dashboard comment contract (+ #134 rollup, same suite).
+#
+# WHY A CONTENT DRIFT-GUARD: the dashboard is a prose contract executed by four
+# lifecycle SKILLs. The falsifiable equivalent of "humans get one stable
+# narrative surface per issue" is asserting (a) the canonical contract file
+# carries the marker + template + phase-transition-only update table (the #116
+# anti-fatigue lock), and (b) all four lifecycle SKILLs cite the contract at
+# their wiring point — a missing citation is exactly how one skill's phase
+# transition would silently stop updating the dashboard.
+#
+# Usage: bash test.sh   (exit 0 = all pass, 1 = any fail)
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$HERE/../../.."
+REF="$PLUGIN_ROOT/references/dashboard-comment.md"
+
+HELPERS="$HERE/../../lib/assert-helpers.sh"
+[ -f "$HELPERS" ] || { echo "✗ missing $HELPERS — cannot run suite" >&2; exit 1; }
+. "$HELPERS"
+
+# ── contract file: marker + template + update-point table + division of labor ──
+assert_file_exists "references/dashboard-comment.md exists" "$REF"
+assert_output_grep "ref: HTML marker for machine location"      "<!-- idd:dashboard -->"          "$REF"
+assert_output_grep "ref: human-facing heading"                  "## 📊 For Reviewer / Collaborator" "$REF"
+assert_output_grep "ref: update points bound to phase transitions ONLY" "只綁 phase 轉換"          "$REF"
+assert_output_grep "ref: anti-fatigue rationale cites the #116 class"   "notification fatigue"    "$REF"
+assert_output_grep "ref: last-updated provenance field"         "last-updated by"                 "$REF"
+assert_output_grep "ref: division of labor vs body Current Status"      "narrative for humans"    "$REF"
+assert_output_grep "ref: update mechanics via marker surgery"   "marker 定位"                      "$REF"
+
+# ── four lifecycle SKILLs wired (each cites the contract at its transition point) ──
+for skill in idd-diagnose idd-implement idd-verify idd-close; do
+  S="$PLUGIN_ROOT/skills/$skill/SKILL.md"
+  assert_file_exists "$skill SKILL.md exists" "$S"
+  assert_output_grep "$skill: cites dashboard contract"  "references/dashboard-comment.md" "$S"
+  assert_output_grep "$skill: names the marker"          "idd:dashboard"                   "$S"
+done
+
+# ── #134 rollup mode (idd-report consumes the same contract) ──
+REPORT="$PLUGIN_ROOT/skills/idd-report/SKILL.md"
+assert_file_exists "idd-report SKILL.md exists" "$REPORT"
+assert_output_grep "report: rollup mode exists"                 "--rollup"            "$REPORT"
+assert_output_grep "report: consumes the dashboard marker"      "idd:dashboard"       "$REPORT"
+assert_output_grep "report: grouping — need attention"          "need attention"      "$REPORT"
+assert_output_grep "report: grouping — stalled"                 "stalled"             "$REPORT"
+assert_output_grep "report: grouping — recently closed"         "recently closed"     "$REPORT"
+assert_output_grep "report: snapshot-only invariant (no write-back)" "snapshot-only"  "$REPORT"
+assert_output_grep "report: registry-based owner mapping (#86)" "collaborators"       "$REPORT"
+
+print_summary "dashboard-comment"

--- a/plugins/issue-driven-dev/skills/idd-close/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-close/SKILL.md
@@ -692,6 +692,8 @@ Skill(skill="issue-driven-dev:idd-update", args="#NNN")
 
 **批次 close 時**：每一個 issue 都要分別跑 idd-update，不是跑一次。
 
+**Dashboard update（#133）**：phase → `closed` 的同一時點，依 [`references/dashboard-comment.md`](../../references/dashboard-comment.md) 更新 dashboard comment（`<!-- idd:dashboard -->` marker 定位；無則首發經 gh-egress）。內容：現況 = 結案一句話（root cause + solution）；你該做什麼 = 無。這是該 issue dashboard 的最後一次更新。
+
 ### Step 6.3: Doc-sync sweep（v2.92+, #220）
 
 > 使用者原話（#220）：「idd-close 的時候更新所有 README 跟 CLAUDE.md 這可能是最後一步吧」— close 是「改動最終狀態確定」的唯一時點，本步把文件 drift 的攔截制度化（motivating incident：che-ical v1.14.0 三處 stale docs 全靠人工 review 才抓到，其中 `README_zh-TW.md` 整份被字面 glob 漏掉）。

--- a/plugins/issue-driven-dev/skills/idd-diagnose/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-diagnose/SKILL.md
@@ -746,6 +746,8 @@ Skill(skill="issue-driven-dev:idd-update", args="#NNN")
 - 下一次回來不知道是 `diagnosed` 還是 `(no phase)`
 - 與 idd-close 2.18.0 同樣的「narrative Auto-Update 沒升 Step」漏跑模式（見 idd-close 2.18.1 fix `4762e64`）
 
+**Dashboard update（#133）**：phase → `diagnosed` 的同一時點，依 [`references/dashboard-comment.md`](../../references/dashboard-comment.md) 更新該 issue 的 dashboard comment（`<!-- idd:dashboard -->` marker 定位；無則首發經 gh-egress）。內容：現況 = root cause 一句話；你該做什麼 = 審 diagnosis / 等 implement。只在 phase 轉換時點更新，中間進度不觸發（anti-fatigue 鐵律見契約檔）。
+
 ## 鐵律
 
 - **不跳過 diagnosis**。就算「很明顯」也要做。簡單的問題做 diagnosis 只要 2 分鐘，但省下的是 2 小時的重工。

--- a/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-implement/SKILL.md
@@ -690,6 +690,8 @@ close 一律透過 `/idd-close #NNN` skill 走：
 
 Implementation comment 完成後，自動執行 `idd-update` 更新 issue body 的 Current Status（phase → `implemented`）。
 
+**Dashboard update（#133）**：phase → `implemented` 的同一時點，依 [`references/dashboard-comment.md`](../../references/dashboard-comment.md) 更新 dashboard comment（`<!-- idd:dashboard -->` marker 定位；無則首發經 gh-egress）。內容：現況 = 改了什麼一句話 + PR ref；你該做什麼 = review PR。只綁 phase 轉換，commit / finding 等中間進度不觸發。
+
 ## Next Step
 
 實作完成後，進入 `verify`：

--- a/plugins/issue-driven-dev/skills/idd-report/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-report/SKILL.md
@@ -29,7 +29,30 @@ allowed-tools:
 /idd-report milestone:UX Redesign             → milestone 下所有 issues
 /idd-report #157 #158 @Hardy1Yang @che        → 指定 issues + tag 人
 /idd-report milestone:UX Redesign @hardy      → milestone + tag
+/idd-report --rollup                          → 跨 open issue 的 human rollup（#134，讀 dashboard comments）
 ```
+
+## Rollup mode（`--rollup`，v2.97.0+，#134）
+
+聚合所有 open issue 的 dashboard comment（[#133 契約](../../references/dashboard-comment.md)）成一份「人這週該看什麼」的視圖。**Pull-only：snapshot-only、不寫回任何 issue、不發任何通知** — 這條 invariant 進 drift-guard（#116 教訓：push 通知的誘惑一律擋在設計層）。
+
+流程：
+
+1. `gh issue list --state open --json number,title,updatedAt,comments`（一次抓，不 N+1）
+2. 每個 issue 找 `<!-- idd:dashboard -->` marker comment（#133 格式；≥2 則取最早、印警告）；無 marker → 以 body `**Phase**:` 降級呈現（標 `(no dashboard)`）
+3. 依 dashboard 內容 + phase 分四組輸出：
+
+| 分組 | 判準 |
+|------|------|
+| 🎯 **need attention this week** | `verified`（awaiting merge）或 dashboard「你該做什麼」指名讀者行動（blocked-on-you） |
+| 🚧 **in progress** | `diagnosed` / `planning` / `implemented` 且 14 天內有活動 |
+| ⏸ **stalled**（>14d） | open 且 `updatedAt` 距今 > 14 天 |
+| ✅ **recently closed**（7d） | closed 且 `closedAt` 距今 ≤ 7 天（`--state all` 補抓） |
+
+4. 責任人映射：dashboard「你該做什麼」有指名時，經 config `collaborators` registry（#86）解析 alias → `@login`（僅顯示、**不**真的 @-mention — rollup 是 pull 視圖，通知不是它的事）
+5. 輸出到 stdout（預設）或 `--publish` 走既有 Step 6–8 Discussions 流程
+
+**與逐 issue 模式的分工**：逐 issue 模式（上方參數）回答「這批 issue 做了什麼」（narrative 報告）；rollup 回答「我現在該把注意力放哪」（triage 視圖）。rollup 不讀 diagnosis / IC comments 全文 — 只消費 dashboard snapshot（single source = #133 契約），所以成本是 O(1 comment/issue)。
 
 ## Configuration
 

--- a/plugins/issue-driven-dev/skills/idd-verify/SKILL.md
+++ b/plugins/issue-driven-dev/skills/idd-verify/SKILL.md
@@ -1117,6 +1117,8 @@ helper 行為見 `scripts/check-ralph-loop.sh`:exit 0 if installed, exit 1 with 
 
 Verify comment 完成後，自動執行 `idd-update` 更新 issue body 的 Current Status。
 
+**Dashboard update（#133）**：phase → `verified` / `needs-fix` 的同一時點，依 [`references/dashboard-comment.md`](../../references/dashboard-comment.md) 更新 dashboard comment（`<!-- idd:dashboard -->` marker 定位；無則首發經 gh-egress）。內容：現況 = verify verdict 一句話；你該做什麼 = merge（verified）/ 等修（needs-fix）。只綁 phase 轉換（anti-fatigue 鐵律見契約檔）。
+
 ## Next Step
 
 驗證通過後：`/issue-driven-dev:idd-close #NNN`


### PR DESCRIPTION
Refs #133
Refs #134

## Cluster: human UX（Line D）

Couple 關係：#134 的 rollup **hard-depend** 於 #133 的 dashboard 契約 — 同 branch、#133 commit 在前（契約凍結後 #134 才動）。

### Commit 1 — dashboard comment 契約（`1307af7`，Refs #133）

- 新 `references/dashboard-comment.md`：`<!-- idd:dashboard -->` marker + 模板（現況一句話 / Blocking / 你該做什麼 / last-updated-by provenance）+ **update 時點表只綁 phase 轉換**（≤5 次/生命週期 — #116 notification-fatigue class 是設計約束）+ 與 body Current Status 分工明文（body = structured for AI；dashboard = narrative for humans）+ marker 定位 comment-surgery 更新機制（首發經 gh-egress、marker 缺失 self-healing）。
- 4 個 lifecycle SKILL（diagnose / implement / verify / close）各於 phase 轉換點接線一段，皆引契約檔。
- Drift-guard suite `dashboard-comment`：契約 tokens + 4 接線引用（RED 5/23 → #133 側 21 綠；7 個 rollup assertions 刻意留 RED 給下一 commit）。

### Commit 2 — idd-report `--rollup`（`583e505`，Refs #134）

- 消費 #133 契約（marker 定位、每 issue O(1) comment，不讀全 thread）→ 四分組：🎯 need attention this week（verified awaiting merge / blocked-on-you）、🚧 in progress（≤14d）、⏸ stalled（>14d）、✅ recently closed（7d）。
- 責任人經 #86 `collaborators` registry 解析 — **僅顯示、不 @-mention**。
- **Pull-only invariant**：snapshot-only、不寫回任何 issue、不發通知（#116 教訓，鎖進 drift-guard）。
- 無 dashboard 的 issue 降級用 body Phase 呈現（標 `(no dashboard)`）。
- Suite 28/28 GREEN；全 sweep 32 suites 0 fail。

### Verification

- 全 plugin suite sweep：**32 suites, 0 fail**（本 branch 基於 main）。
- Issue 結案不由本 PR 觸發 — merge 後由 close ritual 逐一走 gate（issue 編號見頂部 Refs）。
